### PR TITLE
Fixed words extraction from html files

### DIFF
--- a/Part 1/Extract_List.txt
+++ b/Part 1/Extract_List.txt
@@ -1,243 +1,391 @@
+aol:
+doc: 0 frequency: 11
+doc: 24 frequency: 1
+doc: 26 frequency: 1
+
+time:
+doc: 0 frequency: 11
+doc: 1 frequency: 1
+doc: 11 frequency: 1
+doc: 15 frequency: 1
+doc: 21 frequency: 2
+doc: 28 frequency: 1
+
+warner:
+doc: 0 frequency: 10
+
 quickies:
 doc: 0 frequency: 2
 doc: 24 frequency: 2
 doc: 28 frequency: 1
 
 digest:
-doc: 0 frequency: 2
-doc: 24 frequency: 2
-doc: 28 frequency: 2
+doc: 0 frequency: 4
+doc: 24 frequency: 4
+doc: 28 frequency: 4
+
+rec:
+doc: 0 frequency: 1
+doc: 1 frequency: 1
+doc: 2 frequency: 1
+doc: 3 frequency: 1
+doc: 4 frequency: 1
+doc: 5 frequency: 1
+doc: 6 frequency: 1
+doc: 7 frequency: 1
+doc: 8 frequency: 1
+doc: 9 frequency: 1
+doc: 10 frequency: 1
+doc: 11 frequency: 1
+doc: 12 frequency: 1
+doc: 13 frequency: 1
+doc: 14 frequency: 1
+doc: 15 frequency: 1
+doc: 16 frequency: 1
+doc: 17 frequency: 1
+doc: 18 frequency: 1
+doc: 19 frequency: 1
+doc: 20 frequency: 1
+doc: 21 frequency: 1
+doc: 22 frequency: 1
+doc: 23 frequency: 1
+doc: 24 frequency: 1
+doc: 25 frequency: 1
+doc: 26 frequency: 1
+doc: 27 frequency: 1
+doc: 28 frequency: 1
+doc: 29 frequency: 1
+doc: 30 frequency: 1
+
+humor:
+doc: 0 frequency: 1
+doc: 1 frequency: 1
+doc: 2 frequency: 1
+doc: 3 frequency: 1
+doc: 4 frequency: 1
+doc: 5 frequency: 1
+doc: 6 frequency: 1
+doc: 7 frequency: 1
+doc: 8 frequency: 1
+doc: 9 frequency: 1
+doc: 10 frequency: 3
+doc: 11 frequency: 1
+doc: 12 frequency: 1
+doc: 13 frequency: 1
+doc: 14 frequency: 1
+doc: 15 frequency: 1
+doc: 16 frequency: 1
+doc: 17 frequency: 1
+doc: 18 frequency: 1
+doc: 19 frequency: 1
+doc: 20 frequency: 1
+doc: 21 frequency: 1
+doc: 22 frequency: 1
+doc: 23 frequency: 1
+doc: 24 frequency: 1
+doc: 25 frequency: 1
+doc: 26 frequency: 1
+doc: 27 frequency: 1
+doc: 28 frequency: 1
+doc: 29 frequency: 1
+doc: 30 frequency: 1
+
+funny:
+doc: 0 frequency: 4
+doc: 1 frequency: 1
+doc: 2 frequency: 1
+doc: 3 frequency: 1
+doc: 4 frequency: 1
+doc: 5 frequency: 1
+doc: 6 frequency: 1
+doc: 7 frequency: 1
+doc: 8 frequency: 1
+doc: 9 frequency: 1
+doc: 10 frequency: 1
+doc: 11 frequency: 1
+doc: 12 frequency: 1
+doc: 13 frequency: 1
+doc: 14 frequency: 2
+doc: 15 frequency: 1
+doc: 16 frequency: 1
+doc: 17 frequency: 1
+doc: 18 frequency: 1
+doc: 19 frequency: 1
+doc: 20 frequency: 1
+doc: 21 frequency: 1
+doc: 22 frequency: 1
+doc: 23 frequency: 1
+doc: 24 frequency: 4
+doc: 25 frequency: 2
+doc: 26 frequency: 1
+doc: 27 frequency: 1
+doc: 28 frequency: 4
+doc: 29 frequency: 1
+doc: 30 frequency: 1
 
 a:
-doc: 0 frequency: 6
-doc: 1 frequency: 7
-doc: 2 frequency: 5
-doc: 3 frequency: 6
-doc: 4 frequency: 1
-doc: 5 frequency: 2
-doc: 6 frequency: 5
-doc: 7 frequency: 3
-doc: 8 frequency: 14
-doc: 9 frequency: 2
-doc: 10 frequency: 3
-doc: 11 frequency: 2
-doc: 12 frequency: 1
-doc: 13 frequency: 12
-doc: 14 frequency: 13
-doc: 15 frequency: 10
-doc: 16 frequency: 4
-doc: 17 frequency: 7
-doc: 18 frequency: 5
-doc: 19 frequency: 7
-doc: 20 frequency: 4
-doc: 21 frequency: 5
-doc: 22 frequency: 2
-doc: 23 frequency: 3
-doc: 24 frequency: 9
-doc: 25 frequency: 1
-doc: 26 frequency: 1
-doc: 27 frequency: 1
-doc: 28 frequency: 10
-doc: 29 frequency: 1
-doc: 30 frequency: 1
-
-start:
-doc: 0 frequency: 2
-doc: 1 frequency: 2
-doc: 2 frequency: 2
-doc: 3 frequency: 2
-doc: 4 frequency: 2
-doc: 5 frequency: 2
-doc: 6 frequency: 2
-doc: 7 frequency: 2
-doc: 8 frequency: 2
-doc: 9 frequency: 2
-doc: 10 frequency: 2
-doc: 11 frequency: 2
-doc: 12 frequency: 2
-doc: 13 frequency: 2
-doc: 14 frequency: 2
-doc: 15 frequency: 2
-doc: 16 frequency: 2
-doc: 17 frequency: 4
-doc: 18 frequency: 2
-doc: 19 frequency: 2
-doc: 20 frequency: 2
-doc: 21 frequency: 2
-doc: 22 frequency: 2
-doc: 23 frequency: 2
-doc: 24 frequency: 2
-doc: 25 frequency: 2
-doc: 26 frequency: 2
-doc: 27 frequency: 2
-doc: 28 frequency: 3
-doc: 29 frequency: 2
-doc: 30 frequency: 2
-
-of:
 doc: 0 frequency: 7
-doc: 1 frequency: 3
-doc: 2 frequency: 2
-doc: 3 frequency: 4
+doc: 1 frequency: 8
+doc: 2 frequency: 6
+doc: 3 frequency: 8
 doc: 4 frequency: 2
-doc: 5 frequency: 7
-doc: 6 frequency: 5
+doc: 5 frequency: 4
+doc: 6 frequency: 6
 doc: 7 frequency: 4
-doc: 8 frequency: 12
-doc: 9 frequency: 2
-doc: 10 frequency: 5
-doc: 11 frequency: 2
-doc: 12 frequency: 4
-doc: 13 frequency: 11
-doc: 14 frequency: 6
-doc: 15 frequency: 8
-doc: 16 frequency: 2
-doc: 17 frequency: 7
-doc: 18 frequency: 10
-doc: 19 frequency: 12
-doc: 20 frequency: 2
-doc: 21 frequency: 2
-doc: 22 frequency: 2
-doc: 23 frequency: 3
-doc: 24 frequency: 8
-doc: 25 frequency: 2
-doc: 26 frequency: 2
-doc: 27 frequency: 2
-doc: 28 frequency: 19
-doc: 29 frequency: 9
-doc: 30 frequency: 3
-
-stuff:
-doc: 0 frequency: 1
-doc: 1 frequency: 1
-doc: 2 frequency: 1
-doc: 3 frequency: 1
-doc: 4 frequency: 1
-doc: 5 frequency: 1
-doc: 6 frequency: 1
-doc: 7 frequency: 1
-doc: 8 frequency: 1
-doc: 9 frequency: 1
-doc: 10 frequency: 1
-doc: 11 frequency: 1
-doc: 12 frequency: 1
-doc: 13 frequency: 1
-doc: 14 frequency: 1
-doc: 15 frequency: 1
-doc: 16 frequency: 1
-doc: 17 frequency: 1
-doc: 18 frequency: 1
-doc: 19 frequency: 1
-doc: 20 frequency: 1
-doc: 21 frequency: 1
-doc: 22 frequency: 1
-doc: 23 frequency: 1
-doc: 24 frequency: 1
-doc: 25 frequency: 1
-doc: 26 frequency: 1
-doc: 27 frequency: 1
-doc: 28 frequency: 1
-doc: 29 frequency: 1
-doc: 30 frequency: 1
-
-ismap:
-doc: 0 frequency: 1
-doc: 1 frequency: 1
-doc: 2 frequency: 1
-doc: 3 frequency: 1
-doc: 4 frequency: 1
-doc: 5 frequency: 1
-doc: 6 frequency: 1
-doc: 7 frequency: 1
-doc: 8 frequency: 1
-doc: 9 frequency: 1
-doc: 10 frequency: 1
-doc: 11 frequency: 1
-doc: 12 frequency: 1
-doc: 13 frequency: 1
-doc: 14 frequency: 1
-doc: 15 frequency: 1
-doc: 16 frequency: 1
-doc: 17 frequency: 1
-doc: 18 frequency: 1
-doc: 19 frequency: 1
-doc: 20 frequency: 1
-doc: 21 frequency: 1
-doc: 22 frequency: 1
-doc: 23 frequency: 1
-doc: 24 frequency: 1
-doc: 25 frequency: 1
-doc: 26 frequency: 1
-doc: 27 frequency: 1
-doc: 28 frequency: 1
-doc: 29 frequency: 1
-doc: 30 frequency: 1
-
-end:
-doc: 0 frequency: 2
-doc: 1 frequency: 2
-doc: 2 frequency: 2
-doc: 3 frequency: 2
-doc: 4 frequency: 2
-doc: 5 frequency: 2
-doc: 6 frequency: 3
-doc: 7 frequency: 2
-doc: 8 frequency: 2
-doc: 9 frequency: 2
-doc: 10 frequency: 2
-doc: 11 frequency: 2
+doc: 8 frequency: 20
+doc: 9 frequency: 3
+doc: 10 frequency: 4
+doc: 11 frequency: 4
 doc: 12 frequency: 2
-doc: 13 frequency: 2
-doc: 14 frequency: 2
-doc: 15 frequency: 2
-doc: 16 frequency: 2
-doc: 17 frequency: 2
-doc: 18 frequency: 2
-doc: 19 frequency: 3
-doc: 20 frequency: 2
-doc: 21 frequency: 2
-doc: 22 frequency: 2
-doc: 23 frequency: 2
-doc: 24 frequency: 2
+doc: 13 frequency: 15
+doc: 14 frequency: 14
+doc: 15 frequency: 11
+doc: 16 frequency: 6
+doc: 17 frequency: 8
+doc: 18 frequency: 6
+doc: 19 frequency: 9
+doc: 20 frequency: 6
+doc: 21 frequency: 6
+doc: 22 frequency: 3
+doc: 23 frequency: 4
+doc: 24 frequency: 13
 doc: 25 frequency: 2
 doc: 26 frequency: 2
 doc: 27 frequency: 2
-doc: 28 frequency: 3
-doc: 29 frequency: 2
+doc: 28 frequency: 11
+doc: 29 frequency: 3
 doc: 30 frequency: 2
+
+text:
+doc: 0 frequency: 1
+doc: 1 frequency: 1
+doc: 2 frequency: 1
+doc: 3 frequency: 1
+doc: 4 frequency: 1
+doc: 5 frequency: 1
+doc: 6 frequency: 1
+doc: 7 frequency: 1
+doc: 8 frequency: 1
+doc: 9 frequency: 1
+doc: 10 frequency: 3
+doc: 11 frequency: 1
+doc: 12 frequency: 1
+doc: 13 frequency: 1
+doc: 14 frequency: 1
+doc: 15 frequency: 1
+doc: 16 frequency: 1
+doc: 17 frequency: 1
+doc: 18 frequency: 1
+doc: 19 frequency: 1
+doc: 20 frequency: 1
+doc: 21 frequency: 1
+doc: 22 frequency: 1
+doc: 23 frequency: 1
+doc: 24 frequency: 1
+doc: 25 frequency: 1
+doc: 26 frequency: 1
+doc: 27 frequency: 1
+doc: 28 frequency: 1
+doc: 29 frequency: 1
+doc: 30 frequency: 1
+
+decoration:
+doc: 0 frequency: 1
+doc: 1 frequency: 1
+doc: 2 frequency: 1
+doc: 3 frequency: 1
+doc: 4 frequency: 1
+doc: 5 frequency: 1
+doc: 6 frequency: 1
+doc: 7 frequency: 1
+doc: 8 frequency: 1
+doc: 9 frequency: 1
+doc: 10 frequency: 1
+doc: 11 frequency: 1
+doc: 12 frequency: 1
+doc: 13 frequency: 1
+doc: 14 frequency: 1
+doc: 15 frequency: 1
+doc: 16 frequency: 1
+doc: 17 frequency: 1
+doc: 18 frequency: 1
+doc: 19 frequency: 1
+doc: 20 frequency: 1
+doc: 21 frequency: 1
+doc: 22 frequency: 1
+doc: 23 frequency: 1
+doc: 24 frequency: 1
+doc: 25 frequency: 1
+doc: 26 frequency: 1
+doc: 27 frequency: 1
+doc: 28 frequency: 1
+doc: 29 frequency: 1
+doc: 30 frequency: 1
+
+none:
+doc: 0 frequency: 1
+doc: 1 frequency: 1
+doc: 2 frequency: 1
+doc: 3 frequency: 1
+doc: 4 frequency: 1
+doc: 5 frequency: 1
+doc: 6 frequency: 1
+doc: 7 frequency: 1
+doc: 8 frequency: 1
+doc: 9 frequency: 1
+doc: 10 frequency: 1
+doc: 11 frequency: 1
+doc: 12 frequency: 1
+doc: 13 frequency: 1
+doc: 14 frequency: 1
+doc: 15 frequency: 1
+doc: 16 frequency: 1
+doc: 17 frequency: 1
+doc: 18 frequency: 1
+doc: 19 frequency: 1
+doc: 20 frequency: 1
+doc: 21 frequency: 1
+doc: 22 frequency: 1
+doc: 23 frequency: 1
+doc: 24 frequency: 1
+doc: 25 frequency: 1
+doc: 26 frequency: 1
+doc: 27 frequency: 1
+doc: 28 frequency: 1
+doc: 29 frequency: 1
+doc: 30 frequency: 1
+
+hover:
+doc: 0 frequency: 1
+doc: 1 frequency: 1
+doc: 2 frequency: 1
+doc: 3 frequency: 1
+doc: 4 frequency: 1
+doc: 5 frequency: 1
+doc: 6 frequency: 1
+doc: 7 frequency: 1
+doc: 8 frequency: 1
+doc: 9 frequency: 1
+doc: 10 frequency: 1
+doc: 11 frequency: 1
+doc: 12 frequency: 1
+doc: 13 frequency: 1
+doc: 14 frequency: 1
+doc: 15 frequency: 1
+doc: 16 frequency: 1
+doc: 17 frequency: 1
+doc: 18 frequency: 1
+doc: 19 frequency: 1
+doc: 20 frequency: 1
+doc: 21 frequency: 1
+doc: 22 frequency: 1
+doc: 23 frequency: 1
+doc: 24 frequency: 1
+doc: 25 frequency: 1
+doc: 26 frequency: 1
+doc: 27 frequency: 1
+doc: 28 frequency: 1
+doc: 29 frequency: 1
+doc: 30 frequency: 1
+
+color:
+doc: 0 frequency: 1
+doc: 1 frequency: 1
+doc: 2 frequency: 1
+doc: 3 frequency: 1
+doc: 4 frequency: 1
+doc: 5 frequency: 1
+doc: 6 frequency: 1
+doc: 7 frequency: 1
+doc: 8 frequency: 1
+doc: 9 frequency: 1
+doc: 10 frequency: 1
+doc: 11 frequency: 1
+doc: 12 frequency: 1
+doc: 13 frequency: 1
+doc: 14 frequency: 1
+doc: 15 frequency: 1
+doc: 16 frequency: 1
+doc: 17 frequency: 1
+doc: 18 frequency: 1
+doc: 19 frequency: 1
+doc: 20 frequency: 1
+doc: 21 frequency: 1
+doc: 22 frequency: 1
+doc: 23 frequency: 1
+doc: 24 frequency: 1
+doc: 25 frequency: 1
+doc: 26 frequency: 1
+doc: 27 frequency: 1
+doc: 28 frequency: 1
+doc: 29 frequency: 1
+doc: 30 frequency: 1
+
+darkred:
+doc: 0 frequency: 1
+doc: 1 frequency: 1
+doc: 2 frequency: 1
+doc: 3 frequency: 1
+doc: 4 frequency: 1
+doc: 5 frequency: 1
+doc: 6 frequency: 1
+doc: 7 frequency: 1
+doc: 8 frequency: 1
+doc: 9 frequency: 1
+doc: 10 frequency: 1
+doc: 11 frequency: 1
+doc: 12 frequency: 1
+doc: 13 frequency: 1
+doc: 14 frequency: 1
+doc: 15 frequency: 1
+doc: 16 frequency: 1
+doc: 17 frequency: 1
+doc: 18 frequency: 1
+doc: 19 frequency: 1
+doc: 20 frequency: 1
+doc: 21 frequency: 1
+doc: 22 frequency: 1
+doc: 23 frequency: 1
+doc: 24 frequency: 1
+doc: 25 frequency: 1
+doc: 26 frequency: 1
+doc: 27 frequency: 1
+doc: 28 frequency: 1
+doc: 29 frequency: 1
+doc: 30 frequency: 1
 
 rhf:
-doc: 0 frequency: 3
-doc: 1 frequency: 2
-doc: 2 frequency: 2
-doc: 3 frequency: 2
-doc: 4 frequency: 2
-doc: 5 frequency: 2
-doc: 6 frequency: 2
-doc: 7 frequency: 2
-doc: 8 frequency: 2
-doc: 9 frequency: 2
-doc: 10 frequency: 2
-doc: 11 frequency: 2
-doc: 12 frequency: 2
-doc: 13 frequency: 2
-doc: 14 frequency: 2
-doc: 15 frequency: 2
-doc: 16 frequency: 2
-doc: 17 frequency: 2
-doc: 18 frequency: 2
-doc: 19 frequency: 2
-doc: 20 frequency: 2
-doc: 21 frequency: 2
-doc: 22 frequency: 2
-doc: 23 frequency: 2
-doc: 24 frequency: 3
-doc: 25 frequency: 2
-doc: 26 frequency: 2
-doc: 27 frequency: 2
-doc: 28 frequency: 3
-doc: 29 frequency: 2
-doc: 30 frequency: 2
+doc: 0 frequency: 4
+doc: 1 frequency: 3
+doc: 2 frequency: 3
+doc: 3 frequency: 3
+doc: 4 frequency: 3
+doc: 5 frequency: 3
+doc: 6 frequency: 3
+doc: 7 frequency: 3
+doc: 8 frequency: 3
+doc: 9 frequency: 3
+doc: 10 frequency: 3
+doc: 11 frequency: 3
+doc: 12 frequency: 3
+doc: 13 frequency: 3
+doc: 14 frequency: 3
+doc: 15 frequency: 3
+doc: 16 frequency: 3
+doc: 17 frequency: 3
+doc: 18 frequency: 4
+doc: 19 frequency: 3
+doc: 20 frequency: 3
+doc: 21 frequency: 3
+doc: 22 frequency: 3
+doc: 23 frequency: 3
+doc: 24 frequency: 4
+doc: 25 frequency: 3
+doc: 26 frequency: 3
+doc: 27 frequency: 3
+doc: 28 frequency: 4
+doc: 29 frequency: 3
+doc: 30 frequency: 3
 
 joke:
 doc: 0 frequency: 2
@@ -305,6 +453,65 @@ doc: 28 frequency: 2
 doc: 29 frequency: 2
 doc: 30 frequency: 2
 
+request:
+doc: 0 frequency: 1
+doc: 24 frequency: 1
+doc: 28 frequency: 1
+
+netfunny:
+doc: 0 frequency: 1
+doc: 24 frequency: 1
+doc: 28 frequency: 1
+
+com:
+doc: 0 frequency: 4
+doc: 2 frequency: 1
+doc: 3 frequency: 1
+doc: 5 frequency: 1
+doc: 7 frequency: 1
+doc: 8 frequency: 1
+doc: 10 frequency: 1
+doc: 11 frequency: 1
+doc: 14 frequency: 1
+doc: 15 frequency: 1
+doc: 17 frequency: 1
+doc: 18 frequency: 1
+doc: 19 frequency: 2
+doc: 22 frequency: 1
+doc: 23 frequency: 1
+doc: 24 frequency: 3
+doc: 26 frequency: 1
+doc: 28 frequency: 5
+
+guy:
+doc: 0 frequency: 2
+doc: 24 frequency: 1
+doc: 28 frequency: 1
+
+smirk:
+doc: 0 frequency: 1
+doc: 1 frequency: 1
+doc: 2 frequency: 1
+doc: 3 frequency: 1
+doc: 4 frequency: 1
+doc: 5 frequency: 1
+doc: 6 frequency: 1
+doc: 7 frequency: 1
+doc: 10 frequency: 1
+doc: 12 frequency: 1
+doc: 13 frequency: 1
+doc: 15 frequency: 1
+doc: 16 frequency: 1
+doc: 20 frequency: 1
+doc: 21 frequency: 1
+doc: 22 frequency: 1
+doc: 24 frequency: 1
+doc: 25 frequency: 1
+doc: 26 frequency: 1
+doc: 28 frequency: 1
+doc: 29 frequency: 1
+doc: 30 frequency: 1
+
 heard:
 doc: 0 frequency: 2
 doc: 1 frequency: 1
@@ -316,6 +523,34 @@ doc: 26 frequency: 1
 doc: 27 frequency: 1
 doc: 28 frequency: 1
 
+it:
+doc: 0 frequency: 2
+doc: 1 frequency: 1
+doc: 3 frequency: 3
+doc: 5 frequency: 1
+doc: 6 frequency: 1
+doc: 8 frequency: 2
+doc: 9 frequency: 1
+doc: 10 frequency: 1
+doc: 11 frequency: 3
+doc: 12 frequency: 1
+doc: 13 frequency: 5
+doc: 17 frequency: 3
+doc: 18 frequency: 3
+doc: 19 frequency: 3
+doc: 20 frequency: 2
+doc: 22 frequency: 1
+doc: 23 frequency: 4
+doc: 24 frequency: 4
+doc: 25 frequency: 1
+doc: 27 frequency: 1
+doc: 28 frequency: 11
+doc: 29 frequency: 2
+doc: 30 frequency: 1
+
+below:
+doc: 0 frequency: 1
+
 find:
 doc: 0 frequency: 1
 
@@ -324,7 +559,7 @@ doc: 0 frequency: 19
 doc: 1 frequency: 4
 doc: 2 frequency: 4
 doc: 3 frequency: 11
-doc: 4 frequency: 9
+doc: 4 frequency: 11
 doc: 5 frequency: 11
 doc: 6 frequency: 7
 doc: 7 frequency: 4
@@ -333,7 +568,7 @@ doc: 9 frequency: 2
 doc: 10 frequency: 3
 doc: 11 frequency: 28
 doc: 12 frequency: 6
-doc: 13 frequency: 32
+doc: 13 frequency: 33
 doc: 14 frequency: 18
 doc: 15 frequency: 8
 doc: 16 frequency: 1
@@ -343,10 +578,10 @@ doc: 19 frequency: 19
 doc: 20 frequency: 1
 doc: 22 frequency: 1
 doc: 23 frequency: 11
-doc: 24 frequency: 17
+doc: 24 frequency: 18
 doc: 25 frequency: 2
 doc: 26 frequency: 3
-doc: 28 frequency: 48
+doc: 28 frequency: 51
 doc: 29 frequency: 5
 doc: 30 frequency: 3
 
@@ -360,6 +595,39 @@ doc: 28 frequency: 1
 noteworthy:
 doc: 0 frequency: 1
 
+of:
+doc: 0 frequency: 6
+doc: 1 frequency: 2
+doc: 2 frequency: 1
+doc: 3 frequency: 3
+doc: 4 frequency: 1
+doc: 5 frequency: 6
+doc: 6 frequency: 4
+doc: 7 frequency: 3
+doc: 8 frequency: 11
+doc: 9 frequency: 1
+doc: 10 frequency: 4
+doc: 11 frequency: 1
+doc: 12 frequency: 3
+doc: 13 frequency: 10
+doc: 14 frequency: 5
+doc: 15 frequency: 7
+doc: 16 frequency: 1
+doc: 17 frequency: 6
+doc: 18 frequency: 10
+doc: 19 frequency: 11
+doc: 20 frequency: 1
+doc: 21 frequency: 1
+doc: 22 frequency: 1
+doc: 23 frequency: 2
+doc: 24 frequency: 7
+doc: 25 frequency: 1
+doc: 26 frequency: 1
+doc: 27 frequency: 1
+doc: 28 frequency: 18
+doc: 29 frequency: 8
+doc: 30 frequency: 2
+
 recent:
 doc: 0 frequency: 2
 doc: 13 frequency: 1
@@ -372,14 +640,11 @@ doc: 0 frequency: 1
 doc: 13 frequency: 1
 doc: 28 frequency: 1
 
-aol:
-doc: 0 frequency: 4
-
 and:
 doc: 0 frequency: 8
 doc: 1 frequency: 3
 doc: 2 frequency: 3
-doc: 3 frequency: 2
+doc: 3 frequency: 3
 doc: 4 frequency: 3
 doc: 5 frequency: 6
 doc: 6 frequency: 1
@@ -387,21 +652,24 @@ doc: 7 frequency: 6
 doc: 8 frequency: 13
 doc: 9 frequency: 1
 doc: 10 frequency: 8
-doc: 11 frequency: 12
-doc: 12 frequency: 1
+doc: 11 frequency: 14
+doc: 12 frequency: 2
 doc: 13 frequency: 6
 doc: 14 frequency: 12
 doc: 15 frequency: 6
 doc: 16 frequency: 1
-doc: 17 frequency: 2
+doc: 17 frequency: 3
 doc: 18 frequency: 6
-doc: 19 frequency: 2
+doc: 19 frequency: 3
 doc: 21 frequency: 1
 doc: 23 frequency: 8
 doc: 24 frequency: 3
 doc: 28 frequency: 12
 doc: 29 frequency: 7
 doc: 30 frequency: 1
+
+merger:
+doc: 0 frequency: 7
 
 these:
 doc: 0 frequency: 1
@@ -423,15 +691,43 @@ doc: 28 frequency: 6
 doc: 30 frequency: 1
 
 jokes:
-doc: 0 frequency: 2
-doc: 24 frequency: 2
-doc: 28 frequency: 2
+doc: 0 frequency: 4
+doc: 1 frequency: 2
+doc: 2 frequency: 2
+doc: 3 frequency: 2
+doc: 4 frequency: 2
+doc: 5 frequency: 2
+doc: 6 frequency: 2
+doc: 7 frequency: 2
+doc: 8 frequency: 2
+doc: 9 frequency: 2
+doc: 10 frequency: 2
+doc: 11 frequency: 2
+doc: 12 frequency: 2
+doc: 13 frequency: 2
+doc: 14 frequency: 2
+doc: 15 frequency: 2
+doc: 16 frequency: 2
+doc: 17 frequency: 2
+doc: 18 frequency: 2
+doc: 19 frequency: 2
+doc: 20 frequency: 2
+doc: 21 frequency: 2
+doc: 22 frequency: 2
+doc: 23 frequency: 2
+doc: 24 frequency: 5
+doc: 25 frequency: 2
+doc: 26 frequency: 2
+doc: 27 frequency: 2
+doc: 28 frequency: 4
+doc: 29 frequency: 2
+doc: 30 frequency: 2
 
 which:
 doc: 0 frequency: 2
 doc: 3 frequency: 1
 doc: 5 frequency: 1
-doc: 8 frequency: 8
+doc: 8 frequency: 9
 doc: 13 frequency: 2
 doc: 18 frequency: 1
 doc: 19 frequency: 1
@@ -445,6 +741,7 @@ doc: 3 frequency: 1
 doc: 5 frequency: 1
 doc: 8 frequency: 3
 doc: 10 frequency: 2
+doc: 11 frequency: 1
 doc: 13 frequency: 2
 doc: 14 frequency: 1
 doc: 15 frequency: 1
@@ -454,8 +751,29 @@ doc: 24 frequency: 2
 doc: 28 frequency: 2
 doc: 29 frequency: 1
 
-really:
+didn:
 doc: 0 frequency: 1
+doc: 11 frequency: 1
+doc: 24 frequency: 1
+doc: 28 frequency: 1
+
+t:
+doc: 0 frequency: 2
+doc: 2 frequency: 1
+doc: 4 frequency: 2
+doc: 6 frequency: 1
+doc: 7 frequency: 2
+doc: 8 frequency: 7
+doc: 10 frequency: 1
+doc: 11 frequency: 8
+doc: 13 frequency: 1
+doc: 14 frequency: 4
+doc: 21 frequency: 1
+doc: 24 frequency: 2
+doc: 28 frequency: 3
+
+really:
+doc: 0 frequency: 3
 doc: 4 frequency: 1
 doc: 24 frequency: 1
 doc: 28 frequency: 1
@@ -470,35 +788,45 @@ doc: 0 frequency: 1
 doc: 24 frequency: 1
 doc: 28 frequency: 1
 
+separately:
+doc: 0 frequency: 1
+doc: 24 frequency: 1
+doc: 28 frequency: 1
+
 i:
-doc: 0 frequency: 6
+doc: 0 frequency: 7
 doc: 1 frequency: 1
-doc: 3 frequency: 1
-doc: 4 frequency: 2
-doc: 7 frequency: 5
+doc: 3 frequency: 2
+doc: 4 frequency: 4
+doc: 5 frequency: 1
+doc: 7 frequency: 6
 doc: 8 frequency: 5
-doc: 11 frequency: 7
+doc: 10 frequency: 1
+doc: 11 frequency: 10
 doc: 13 frequency: 5
-doc: 14 frequency: 8
-doc: 16 frequency: 1
-doc: 19 frequency: 5
-doc: 20 frequency: 1
-doc: 21 frequency: 2
-doc: 23 frequency: 1
+doc: 14 frequency: 16
+doc: 16 frequency: 2
+doc: 19 frequency: 8
+doc: 20 frequency: 2
+doc: 21 frequency: 3
+doc: 22 frequency: 1
+doc: 23 frequency: 2
 doc: 24 frequency: 6
-doc: 26 frequency: 1
-doc: 28 frequency: 21
+doc: 25 frequency: 1
+doc: 26 frequency: 2
+doc: 28 frequency: 28
 doc: 30 frequency: 3
 
 post:
 doc: 0 frequency: 1
 doc: 11 frequency: 2
-doc: 24 frequency: 1
+doc: 24 frequency: 2
 doc: 28 frequency: 1
 
 such:
 doc: 0 frequency: 1
 doc: 2 frequency: 1
+doc: 9 frequency: 1
 doc: 14 frequency: 1
 doc: 23 frequency: 1
 doc: 24 frequency: 1
@@ -522,6 +850,7 @@ doc: 14 frequency: 3
 doc: 15 frequency: 3
 doc: 17 frequency: 1
 doc: 19 frequency: 1
+doc: 20 frequency: 1
 doc: 21 frequency: 1
 doc: 23 frequency: 2
 doc: 24 frequency: 1
@@ -553,7 +882,7 @@ doc: 8 frequency: 15
 doc: 9 frequency: 1
 doc: 10 frequency: 3
 doc: 11 frequency: 5
-doc: 13 frequency: 10
+doc: 13 frequency: 12
 doc: 14 frequency: 7
 doc: 15 frequency: 4
 doc: 17 frequency: 2
@@ -615,11 +944,16 @@ doc: 22 frequency: 1
 doc: 23 frequency: 3
 doc: 24 frequency: 2
 doc: 25 frequency: 1
-doc: 28 frequency: 6
+doc: 28 frequency: 7
 doc: 29 frequency: 2
 doc: 30 frequency: 1
 
 enjoy:
+doc: 0 frequency: 1
+doc: 24 frequency: 1
+doc: 28 frequency: 1
+
+digests:
 doc: 0 frequency: 1
 doc: 24 frequency: 1
 doc: 28 frequency: 1
@@ -631,7 +965,7 @@ doc: 3 frequency: 1
 doc: 5 frequency: 3
 doc: 10 frequency: 1
 doc: 24 frequency: 1
-doc: 28 frequency: 3
+doc: 28 frequency: 4
 
 want:
 doc: 0 frequency: 2
@@ -647,9 +981,10 @@ doc: 24 frequency: 1
 doc: 28 frequency: 1
 
 with:
-doc: 0 frequency: 3
+doc: 0 frequency: 4
 doc: 4 frequency: 1
 doc: 5 frequency: 1
+doc: 6 frequency: 1
 doc: 8 frequency: 4
 doc: 9 frequency: 1
 doc: 11 frequency: 1
@@ -668,7 +1003,7 @@ doc: 30 frequency: 1
 in:
 doc: 0 frequency: 5
 doc: 1 frequency: 3
-doc: 2 frequency: 4
+doc: 2 frequency: 5
 doc: 3 frequency: 2
 doc: 5 frequency: 6
 doc: 6 frequency: 1
@@ -677,8 +1012,9 @@ doc: 8 frequency: 4
 doc: 10 frequency: 1
 doc: 11 frequency: 4
 doc: 12 frequency: 1
-doc: 13 frequency: 9
+doc: 13 frequency: 10
 doc: 15 frequency: 3
+doc: 16 frequency: 1
 doc: 17 frequency: 4
 doc: 18 frequency: 6
 doc: 19 frequency: 9
@@ -686,17 +1022,77 @@ doc: 22 frequency: 1
 doc: 23 frequency: 2
 doc: 24 frequency: 4
 doc: 25 frequency: 1
-doc: 28 frequency: 7
+doc: 28 frequency: 9
 doc: 29 frequency: 3
-doc: 30 frequency: 1
+doc: 30 frequency: 3
 
 title:
 doc: 0 frequency: 1
 doc: 24 frequency: 1
 doc: 28 frequency: 1
 
-what:
+ed:
 doc: 0 frequency: 2
+doc: 9 frequency: 1
+doc: 12 frequency: 2
+doc: 14 frequency: 1
+doc: 24 frequency: 1
+doc: 28 frequency: 1
+
+gt:
+doc: 0 frequency: 11
+doc: 8 frequency: 4
+doc: 13 frequency: 4
+doc: 24 frequency: 8
+doc: 28 frequency: 39
+
+from:
+doc: 0 frequency: 5
+doc: 3 frequency: 3
+doc: 6 frequency: 1
+doc: 10 frequency: 2
+doc: 12 frequency: 2
+doc: 13 frequency: 3
+doc: 15 frequency: 1
+doc: 16 frequency: 1
+doc: 17 frequency: 1
+doc: 18 frequency: 2
+doc: 19 frequency: 1
+doc: 24 frequency: 5
+doc: 26 frequency: 2
+doc: 28 frequency: 14
+
+egin:
+doc: 0 frequency: 1
+
+interchange:
+doc: 0 frequency: 1
+
+ubc:
+doc: 0 frequency: 1
+
+ca:
+doc: 0 frequency: 1
+doc: 12 frequency: 1
+doc: 19 frequency: 1
+doc: 28 frequency: 2
+
+edmund:
+doc: 0 frequency: 1
+
+gin:
+doc: 0 frequency: 1
+
+organization:
+doc: 0 frequency: 2
+doc: 28 frequency: 2
+
+huh:
+doc: 0 frequency: 1
+
+what:
+doc: 0 frequency: 3
+doc: 3 frequency: 1
 doc: 4 frequency: 1
 doc: 5 frequency: 3
 doc: 7 frequency: 1
@@ -704,6 +1100,24 @@ doc: 8 frequency: 1
 doc: 11 frequency: 4
 doc: 13 frequency: 1
 doc: 14 frequency: 1
+doc: 24 frequency: 1
+
+subject:
+doc: 0 frequency: 5
+doc: 12 frequency: 2
+doc: 24 frequency: 5
+doc: 28 frequency: 10
+
+just:
+doc: 0 frequency: 2
+doc: 7 frequency: 1
+doc: 11 frequency: 10
+doc: 12 frequency: 1
+doc: 17 frequency: 1
+doc: 19 frequency: 2
+doc: 20 frequency: 1
+doc: 22 frequency: 2
+doc: 29 frequency: 1
 
 about:
 doc: 0 frequency: 1
@@ -718,40 +1132,126 @@ doc: 26 frequency: 1
 doc: 27 frequency: 3
 doc: 28 frequency: 2
 
-just:
+can:
 doc: 0 frequency: 1
-doc: 7 frequency: 1
-doc: 11 frequency: 10
-doc: 12 frequency: 1
-doc: 19 frequency: 2
-doc: 20 frequency: 1
-doc: 22 frequency: 2
-doc: 29 frequency: 1
+doc: 2 frequency: 1
+doc: 5 frequency: 1
+doc: 6 frequency: 1
+doc: 11 frequency: 7
+doc: 13 frequency: 1
+doc: 14 frequency: 2
+doc: 15 frequency: 1
+doc: 21 frequency: 1
+doc: 24 frequency: 1
+
+wait:
+doc: 0 frequency: 1
+
+letters:
+doc: 0 frequency: 1
 
 editor:
 doc: 0 frequency: 1
+doc: 19 frequency: 1
 
 consisting:
 doc: 0 frequency: 1
 
-time:
-doc: 0 frequency: 3
-doc: 11 frequency: 1
+all:
+doc: 0 frequency: 1
+doc: 1 frequency: 1
+doc: 2 frequency: 1
+doc: 3 frequency: 1
+doc: 5 frequency: 1
+doc: 6 frequency: 2
+doc: 10 frequency: 1
+doc: 13 frequency: 2
+doc: 14 frequency: 4
 doc: 15 frequency: 1
+doc: 17 frequency: 1
+doc: 18 frequency: 1
+doc: 19 frequency: 1
+doc: 24 frequency: 1
+doc: 28 frequency: 6
+doc: 29 frequency: 7
+
+caps:
+doc: 0 frequency: 1
+
+me:
+doc: 0 frequency: 1
+doc: 4 frequency: 2
+doc: 6 frequency: 1
+doc: 7 frequency: 1
+doc: 8 frequency: 1
+doc: 13 frequency: 1
+doc: 14 frequency: 1
+doc: 16 frequency: 1
+doc: 17 frequency: 2
+doc: 20 frequency: 1
+doc: 22 frequency: 1
+doc: 25 frequency: 1
+doc: 28 frequency: 4
+
+too:
+doc: 0 frequency: 2
+doc: 18 frequency: 1
+doc: 30 frequency: 2
+
+p:
+doc: 0 frequency: 1
+doc: 9 frequency: 1
+doc: 13 frequency: 2
+doc: 16 frequency: 1
+doc: 28 frequency: 1
+
+cunnin:
+doc: 0 frequency: 1
+
+yahoo:
+doc: 0 frequency: 1
+doc: 28 frequency: 1
+
+patrick:
+doc: 0 frequency: 1
+
+cunningham:
+doc: 0 frequency: 1
+
+amp:
+doc: 0 frequency: 1
+doc: 8 frequency: 5
+doc: 24 frequency: 5
+doc: 25 frequency: 1
+
+now:
+doc: 0 frequency: 1
+doc: 4 frequency: 1
+doc: 8 frequency: 2
+doc: 10 frequency: 1
+doc: 15 frequency: 1
+doc: 17 frequency: 1
+doc: 19 frequency: 1
+doc: 21 frequency: 1
+doc: 23 frequency: 1
+doc: 30 frequency: 1
 
 we:
 doc: 0 frequency: 2
 doc: 1 frequency: 1
-doc: 9 frequency: 1
+doc: 9 frequency: 2
 doc: 13 frequency: 1
+doc: 15 frequency: 1
 doc: 17 frequency: 1
 doc: 19 frequency: 1
-doc: 24 frequency: 2
+doc: 24 frequency: 3
 doc: 28 frequency: 1
-doc: 30 frequency: 2
+doc: 29 frequency: 2
+doc: 30 frequency: 3
 
 know:
 doc: 0 frequency: 1
+doc: 4 frequency: 1
 doc: 24 frequency: 1
 
 real:
@@ -768,6 +1268,7 @@ doc: 0 frequency: 2
 doc: 1 frequency: 1
 doc: 2 frequency: 2
 doc: 3 frequency: 3
+doc: 4 frequency: 1
 doc: 5 frequency: 2
 doc: 6 frequency: 1
 doc: 7 frequency: 2
@@ -775,15 +1276,17 @@ doc: 8 frequency: 1
 doc: 10 frequency: 1
 doc: 12 frequency: 1
 doc: 13 frequency: 4
+doc: 14 frequency: 1
 doc: 15 frequency: 4
 doc: 16 frequency: 2
+doc: 17 frequency: 1
 doc: 18 frequency: 1
 doc: 19 frequency: 1
 doc: 20 frequency: 1
 doc: 21 frequency: 3
 doc: 24 frequency: 3
 doc: 25 frequency: 2
-doc: 28 frequency: 9
+doc: 28 frequency: 10
 doc: 29 frequency: 2
 doc: 30 frequency: 2
 
@@ -791,10 +1294,28 @@ ted:
 doc: 0 frequency: 1
 doc: 19 frequency: 1
 
-too:
+jane:
+doc: 0 frequency: 2
+
+s:
+doc: 0 frequency: 5
+doc: 1 frequency: 1
+doc: 4 frequency: 3
+doc: 5 frequency: 2
+doc: 8 frequency: 3
+doc: 10 frequency: 2
+doc: 11 frequency: 2
+doc: 14 frequency: 1
+doc: 18 frequency: 2
+doc: 19 frequency: 4
+doc: 20 frequency: 2
+doc: 24 frequency: 1
+doc: 25 frequency: 1
+doc: 28 frequency: 7
+doc: 30 frequency: 1
+
+separation:
 doc: 0 frequency: 1
-doc: 18 frequency: 1
-doc: 30 frequency: 2
 
 much:
 doc: 0 frequency: 1
@@ -802,6 +1323,7 @@ doc: 10 frequency: 1
 doc: 12 frequency: 1
 doc: 13 frequency: 1
 doc: 19 frequency: 2
+doc: 28 frequency: 1
 doc: 29 frequency: 1
 doc: 30 frequency: 2
 
@@ -810,11 +1332,13 @@ doc: 0 frequency: 1
 
 ever:
 doc: 0 frequency: 1
+doc: 12 frequency: 2
 doc: 28 frequency: 1
 
 go:
 doc: 0 frequency: 1
 doc: 5 frequency: 1
+doc: 14 frequency: 3
 doc: 17 frequency: 1
 doc: 21 frequency: 1
 doc: 23 frequency: 1
@@ -823,7 +1347,7 @@ out:
 doc: 0 frequency: 1
 doc: 2 frequency: 1
 doc: 3 frequency: 1
-doc: 5 frequency: 1
+doc: 5 frequency: 3
 doc: 7 frequency: 1
 doc: 12 frequency: 1
 doc: 17 frequency: 1
@@ -832,9 +1356,6 @@ doc: 21 frequency: 1
 doc: 23 frequency: 1
 doc: 26 frequency: 1
 doc: 28 frequency: 1
-
-guy:
-doc: 0 frequency: 1
 
 who:
 doc: 0 frequency: 1
@@ -854,7 +1375,7 @@ an:
 doc: 0 frequency: 1
 doc: 2 frequency: 1
 doc: 3 frequency: 1
-doc: 8 frequency: 2
+doc: 8 frequency: 3
 doc: 12 frequency: 1
 doc: 13 frequency: 2
 doc: 15 frequency: 1
@@ -864,15 +1385,56 @@ doc: 19 frequency: 3
 doc: 24 frequency: 2
 doc: 28 frequency: 1
 
+account:
+doc: 0 frequency: 1
+doc: 8 frequency: 2
+
+drgonzalez:
+doc: 0 frequency: 1
+
+webtv:
+doc: 0 frequency: 1
+
+net:
+doc: 0 frequency: 1
+doc: 1 frequency: 1
+doc: 19 frequency: 1
+doc: 28 frequency: 2
+doc: 29 frequency: 1
+
+pedro:
+doc: 0 frequency: 1
+
+gonzalez:
+doc: 0 frequency: 1
+
+new:
+doc: 0 frequency: 1
+doc: 2 frequency: 2
+doc: 5 frequency: 1
+doc: 8 frequency: 7
+doc: 14 frequency: 3
+doc: 19 frequency: 2
+doc: 20 frequency: 1
+doc: 21 frequency: 3
+doc: 24 frequency: 1
+doc: 28 frequency: 6
+
 york:
 doc: 0 frequency: 1
 doc: 8 frequency: 1
 
+reuters:
+doc: 0 frequency: 1
+
 top:
 doc: 0 frequency: 1
+doc: 27 frequency: 3
 
 internet:
 doc: 0 frequency: 1
+doc: 19 frequency: 1
+doc: 25 frequency: 1
 
 service:
 doc: 0 frequency: 1
@@ -884,17 +1446,25 @@ doc: 0 frequency: 1
 
 america:
 doc: 0 frequency: 2
+doc: 8 frequency: 1
 doc: 24 frequency: 1
 
 online:
 doc: 0 frequency: 2
+doc: 22 frequency: 1
+
+inc:
+doc: 0 frequency: 2
+doc: 28 frequency: 2
 
 buy:
 doc: 0 frequency: 1
 doc: 24 frequency: 1
 
-warner:
-doc: 0 frequency: 3
+world:
+doc: 0 frequency: 2
+doc: 5 frequency: 2
+doc: 28 frequency: 2
 
 biggest:
 doc: 0 frequency: 1
@@ -902,41 +1472,66 @@ doc: 0 frequency: 1
 media:
 doc: 0 frequency: 1
 
+company:
+doc: 0 frequency: 1
+doc: 8 frequency: 1
+doc: 15 frequency: 1
+doc: 19 frequency: 1
+doc: 23 frequency: 1
+doc: 28 frequency: 1
+
 billion:
 doc: 0 frequency: 1
 doc: 18 frequency: 1
+
+stock:
+doc: 0 frequency: 1
+doc: 8 frequency: 1
+doc: 19 frequency: 3
+doc: 28 frequency: 1
 
 companies:
 doc: 0 frequency: 1
 
 said:
 doc: 0 frequency: 1
+doc: 4 frequency: 1
 doc: 5 frequency: 1
+doc: 7 frequency: 1
 doc: 8 frequency: 1
-doc: 11 frequency: 2
+doc: 11 frequency: 7
 doc: 12 frequency: 1
-doc: 14 frequency: 1
+doc: 14 frequency: 2
 doc: 18 frequency: 2
+doc: 24 frequency: 1
+doc: 28 frequency: 5
+
+monday:
+doc: 0 frequency: 1
+doc: 28 frequency: 1
 
 guess:
 doc: 0 frequency: 1
 doc: 28 frequency: 2
 
 this:
-doc: 0 frequency: 1
+doc: 0 frequency: 2
 doc: 2 frequency: 1
-doc: 5 frequency: 2
-doc: 6 frequency: 3
+doc: 3 frequency: 1
+doc: 5 frequency: 3
+doc: 6 frequency: 4
 doc: 7 frequency: 1
 doc: 11 frequency: 2
 doc: 13 frequency: 6
-doc: 15 frequency: 1
+doc: 15 frequency: 2
 doc: 17 frequency: 2
 doc: 18 frequency: 2
 doc: 19 frequency: 2
+doc: 21 frequency: 1
 doc: 22 frequency: 2
-doc: 23 frequency: 2
+doc: 23 frequency: 3
 doc: 24 frequency: 3
+doc: 25 frequency: 1
 doc: 28 frequency: 6
 doc: 29 frequency: 1
 
@@ -950,23 +1545,23 @@ doc: 4 frequency: 1
 doc: 5 frequency: 3
 doc: 6 frequency: 1
 doc: 7 frequency: 1
-doc: 8 frequency: 5
+doc: 8 frequency: 6
 doc: 10 frequency: 1
-doc: 11 frequency: 1
+doc: 11 frequency: 3
 doc: 12 frequency: 1
 doc: 13 frequency: 5
 doc: 14 frequency: 4
 doc: 15 frequency: 1
-doc: 18 frequency: 3
-doc: 19 frequency: 3
+doc: 18 frequency: 4
+doc: 19 frequency: 5
 doc: 20 frequency: 1
 doc: 21 frequency: 1
-doc: 23 frequency: 4
+doc: 23 frequency: 5
 doc: 24 frequency: 3
 doc: 26 frequency: 1
-doc: 28 frequency: 9
+doc: 28 frequency: 12
 doc: 29 frequency: 1
-doc: 30 frequency: 1
+doc: 30 frequency: 2
 
 next:
 doc: 0 frequency: 1
@@ -975,11 +1570,12 @@ doc: 11 frequency: 1
 doc: 18 frequency: 1
 doc: 19 frequency: 1
 doc: 24 frequency: 1
-doc: 28 frequency: 2
+doc: 28 frequency: 3
 
 try:
 doc: 0 frequency: 2
 doc: 2 frequency: 1
+doc: 3 frequency: 1
 doc: 12 frequency: 1
 doc: 15 frequency: 1
 doc: 16 frequency: 1
@@ -1004,16 +1600,28 @@ doc: 8 frequency: 3
 doc: 10 frequency: 1
 doc: 11 frequency: 3
 doc: 12 frequency: 1
-doc: 13 frequency: 3
+doc: 13 frequency: 4
 doc: 14 frequency: 4
 doc: 15 frequency: 1
 doc: 17 frequency: 2
 doc: 18 frequency: 1
 doc: 19 frequency: 5
 doc: 23 frequency: 3
-doc: 24 frequency: 3
-doc: 28 frequency: 2
+doc: 24 frequency: 4
+doc: 28 frequency: 3
 doc: 29 frequency: 1
+
+hbo:
+doc: 0 frequency: 1
+
+ll:
+doc: 0 frequency: 1
+doc: 5 frequency: 1
+doc: 14 frequency: 2
+doc: 15 frequency: 1
+doc: 17 frequency: 1
+doc: 28 frequency: 1
+doc: 29 frequency: 2
 
 get:
 doc: 0 frequency: 1
@@ -1028,6 +1636,30 @@ doc: 28 frequency: 1
 busy:
 doc: 0 frequency: 1
 
+signal:
+doc: 0 frequency: 1
+
+axeice:
+doc: 0 frequency: 1
+
+columbus:
+doc: 0 frequency: 1
+
+rr:
+doc: 0 frequency: 1
+
+chops:
+doc: 0 frequency: 1
+
+frozen:
+doc: 0 frequency: 1
+
+water:
+doc: 0 frequency: 1
+doc: 5 frequency: 1
+doc: 17 frequency: 2
+doc: 28 frequency: 2
+
 got:
 doc: 0 frequency: 3
 doc: 4 frequency: 3
@@ -1037,16 +1669,42 @@ doc: 11 frequency: 3
 doc: 14 frequency: 1
 doc: 21 frequency: 1
 
+you:
+doc: 0 frequency: 3
+doc: 1 frequency: 1
+doc: 2 frequency: 5
+doc: 3 frequency: 3
+doc: 4 frequency: 2
+doc: 5 frequency: 8
+doc: 6 frequency: 1
+doc: 7 frequency: 1
+doc: 8 frequency: 3
+doc: 11 frequency: 10
+doc: 13 frequency: 1
+doc: 14 frequency: 2
+doc: 15 frequency: 1
+doc: 17 frequency: 4
+doc: 19 frequency: 2
+doc: 20 frequency: 1
+doc: 23 frequency: 7
+doc: 24 frequency: 2
+doc: 28 frequency: 4
+doc: 30 frequency: 2
+
+buyout:
+doc: 0 frequency: 1
+
 begin:
 doc: 0 frequency: 2
 
 wonder:
 doc: 0 frequency: 1
 doc: 5 frequency: 1
+doc: 28 frequency: 1
 
 if:
 doc: 0 frequency: 1
-doc: 1 frequency: 1
+doc: 1 frequency: 2
 doc: 4 frequency: 2
 doc: 5 frequency: 6
 doc: 6 frequency: 1
@@ -1054,7 +1712,7 @@ doc: 13 frequency: 1
 doc: 17 frequency: 1
 doc: 24 frequency: 2
 doc: 25 frequency: 1
-doc: 28 frequency: 1
+doc: 28 frequency: 2
 doc: 30 frequency: 1
 
 cnn:
@@ -1066,7 +1724,7 @@ doc: 1 frequency: 4
 doc: 2 frequency: 1
 doc: 3 frequency: 1
 doc: 5 frequency: 4
-doc: 6 frequency: 1
+doc: 6 frequency: 2
 doc: 8 frequency: 1
 doc: 10 frequency: 1
 doc: 13 frequency: 6
@@ -1078,7 +1736,7 @@ doc: 21 frequency: 1
 doc: 22 frequency: 2
 doc: 23 frequency: 1
 doc: 24 frequency: 1
-doc: 25 frequency: 1
+doc: 25 frequency: 2
 doc: 28 frequency: 9
 
 going:
@@ -1096,37 +1754,87 @@ broadcasts:
 doc: 0 frequency: 1
 doc: 5 frequency: 1
 
-how:
-doc: 0 frequency: 2
-doc: 17 frequency: 1
-doc: 19 frequency: 1
-doc: 25 frequency: 1
+ve:
+doc: 0 frequency: 1
+doc: 4 frequency: 1
+doc: 24 frequency: 1
+doc: 26 frequency: 1
 doc: 28 frequency: 1
 
-merger:
+news:
+doc: 0 frequency: 1
+doc: 3 frequency: 1
+
+ztf:
+doc: 0 frequency: 1
+
+one:
+doc: 0 frequency: 1
+doc: 1 frequency: 1
+doc: 2 frequency: 1
+doc: 7 frequency: 1
+doc: 13 frequency: 1
+doc: 18 frequency: 1
+doc: 19 frequency: 1
+doc: 23 frequency: 1
+doc: 24 frequency: 1
+doc: 28 frequency: 1
+
+zach:
+doc: 0 frequency: 1
+
+frey:
+doc: 0 frequency: 1
+
+how:
 doc: 0 frequency: 2
+doc: 6 frequency: 2
+doc: 17 frequency: 2
+doc: 19 frequency: 1
+doc: 25 frequency: 1
+doc: 28 frequency: 2
+
+started:
+doc: 0 frequency: 1
+
+my:
+doc: 0 frequency: 1
+doc: 1 frequency: 2
+doc: 7 frequency: 5
+doc: 8 frequency: 6
+doc: 11 frequency: 4
+doc: 13 frequency: 4
+doc: 14 frequency: 2
+doc: 16 frequency: 5
+doc: 17 frequency: 1
+doc: 19 frequency: 6
+doc: 21 frequency: 2
+doc: 24 frequency: 1
+doc: 26 frequency: 1
+doc: 28 frequency: 7
 
 vision:
 doc: 0 frequency: 1
 
 was:
 doc: 0 frequency: 1
-doc: 1 frequency: 1
+doc: 1 frequency: 2
 doc: 3 frequency: 2
 doc: 4 frequency: 1
 doc: 6 frequency: 1
 doc: 7 frequency: 3
-doc: 8 frequency: 2
+doc: 8 frequency: 3
 doc: 9 frequency: 1
 doc: 11 frequency: 2
 doc: 12 frequency: 3
 doc: 13 frequency: 2
+doc: 16 frequency: 2
 doc: 17 frequency: 1
 doc: 18 frequency: 6
 doc: 20 frequency: 1
 doc: 24 frequency: 1
 doc: 26 frequency: 2
-doc: 28 frequency: 4
+doc: 28 frequency: 5
 doc: 29 frequency: 2
 
 planned:
@@ -1151,12 +1859,60 @@ doc: 14 frequency: 1
 doc: 15 frequency: 2
 doc: 17 frequency: 1
 
+scene:
+doc: 0 frequency: 1
+doc: 13 frequency: 1
+
 steve:
-doc: 0 frequency: 2
+doc: 0 frequency: 3
+
+case:
+doc: 0 frequency: 6
+doc: 5 frequency: 4
+doc: 19 frequency: 1
+doc: 29 frequency: 1
 
 home:
+doc: 0 frequency: 2
+doc: 1 frequency: 1
+doc: 2 frequency: 1
+doc: 3 frequency: 1
+doc: 4 frequency: 1
+doc: 5 frequency: 1
+doc: 6 frequency: 1
+doc: 7 frequency: 1
+doc: 8 frequency: 1
+doc: 9 frequency: 1
+doc: 10 frequency: 1
+doc: 11 frequency: 1
+doc: 12 frequency: 1
+doc: 13 frequency: 1
+doc: 14 frequency: 1
+doc: 15 frequency: 1
+doc: 16 frequency: 1
+doc: 17 frequency: 1
+doc: 18 frequency: 1
+doc: 19 frequency: 1
+doc: 20 frequency: 1
+doc: 21 frequency: 1
+doc: 22 frequency: 1
+doc: 23 frequency: 3
+doc: 24 frequency: 1
+doc: 25 frequency: 1
+doc: 26 frequency: 1
+doc: 27 frequency: 1
+doc: 28 frequency: 1
+doc: 29 frequency: 1
+doc: 30 frequency: 3
+
+mcclean:
 doc: 0 frequency: 1
-doc: 23 frequency: 1
+
+virginia:
+doc: 0 frequency: 1
+doc: 10 frequency: 1
+doc: 16 frequency: 1
+doc: 21 frequency: 1
 
 lighting:
 doc: 0 frequency: 1
@@ -1165,6 +1921,9 @@ oddly:
 doc: 0 frequency: 1
 
 dark:
+doc: 0 frequency: 1
+
+menacing:
 doc: 0 frequency: 1
 
 addition:
@@ -1184,8 +1943,13 @@ doc: 14 frequency: 1
 bottle:
 doc: 0 frequency: 1
 
+table:
+doc: 0 frequency: 1
+doc: 23 frequency: 1
+
 there:
 doc: 0 frequency: 1
+doc: 4 frequency: 3
 doc: 5 frequency: 1
 doc: 9 frequency: 1
 doc: 10 frequency: 1
@@ -1193,13 +1957,15 @@ doc: 13 frequency: 1
 doc: 14 frequency: 1
 doc: 15 frequency: 1
 doc: 18 frequency: 1
+doc: 25 frequency: 1
 doc: 26 frequency: 1
 doc: 28 frequency: 1
+doc: 29 frequency: 1
 
 some:
 doc: 0 frequency: 1
 doc: 9 frequency: 1
-doc: 11 frequency: 1
+doc: 11 frequency: 7
 doc: 12 frequency: 1
 doc: 13 frequency: 1
 doc: 15 frequency: 1
@@ -1223,15 +1989,32 @@ background:
 doc: 0 frequency: 1
 
 gerry:
-doc: 0 frequency: 2
+doc: 0 frequency: 4
+
+levin:
+doc: 0 frequency: 1
+
+so:
+doc: 0 frequency: 1
+doc: 5 frequency: 1
+doc: 8 frequency: 4
+doc: 9 frequency: 1
+doc: 11 frequency: 7
+doc: 13 frequency: 2
+doc: 14 frequency: 1
+doc: 15 frequency: 1
+doc: 23 frequency: 3
+doc: 24 frequency: 3
+doc: 25 frequency: 1
+doc: 28 frequency: 2
 
 do:
 doc: 0 frequency: 3
 doc: 3 frequency: 2
 doc: 5 frequency: 3
-doc: 6 frequency: 1
+doc: 6 frequency: 2
 doc: 10 frequency: 1
-doc: 11 frequency: 1
+doc: 11 frequency: 2
 doc: 13 frequency: 1
 doc: 14 frequency: 1
 doc: 17 frequency: 1
@@ -1239,30 +2022,19 @@ doc: 23 frequency: 1
 doc: 25 frequency: 1
 doc: 28 frequency: 1
 
-you:
+tonight:
 doc: 0 frequency: 1
-doc: 1 frequency: 1
-doc: 2 frequency: 5
-doc: 3 frequency: 2
-doc: 4 frequency: 1
-doc: 5 frequency: 6
-doc: 6 frequency: 1
-doc: 7 frequency: 1
-doc: 8 frequency: 3
-doc: 11 frequency: 10
-doc: 13 frequency: 1
-doc: 15 frequency: 1
-doc: 17 frequency: 1
-doc: 19 frequency: 2
-doc: 20 frequency: 1
-doc: 23 frequency: 7
-doc: 28 frequency: 3
-doc: 30 frequency: 2
 
 every:
 doc: 0 frequency: 1
 doc: 10 frequency: 1
 doc: 20 frequency: 1
+doc: 23 frequency: 1
+
+night:
+doc: 0 frequency: 1
+doc: 13 frequency: 1
+doc: 28 frequency: 1
 
 take:
 doc: 0 frequency: 1
@@ -1281,39 +2053,37 @@ doc: 18 frequency: 1
 doc: 19 frequency: 1
 doc: 28 frequency: 1
 
-ad:
+note:
 doc: 0 frequency: 1
-doc: 1 frequency: 1
+doc: 9 frequency: 1
+doc: 14 frequency: 1
+
+they:
+doc: 0 frequency: 2
+doc: 5 frequency: 1
+doc: 8 frequency: 2
+doc: 9 frequency: 1
+doc: 10 frequency: 3
+doc: 13 frequency: 2
+doc: 23 frequency: 1
+doc: 24 frequency: 2
+
+re:
+doc: 0 frequency: 2
 doc: 3 frequency: 1
 doc: 4 frequency: 1
-doc: 5 frequency: 1
-doc: 6 frequency: 1
-doc: 7 frequency: 1
-doc: 8 frequency: 1
-doc: 9 frequency: 1
-doc: 10 frequency: 1
-doc: 11 frequency: 1
-doc: 13 frequency: 1
-doc: 14 frequency: 1
-doc: 15 frequency: 2
-doc: 17 frequency: 1
-doc: 19 frequency: 1
-doc: 20 frequency: 1
-doc: 21 frequency: 1
-doc: 22 frequency: 1
-doc: 23 frequency: 1
-doc: 25 frequency: 1
-doc: 26 frequency: 1
-doc: 29 frequency: 1
-doc: 30 frequency: 1
+doc: 6 frequency: 2
+doc: 24 frequency: 1
+doc: 28 frequency: 1
+doc: 29 frequency: 2
 
-mirrored:
+best:
 doc: 0 frequency: 1
-doc: 1 frequency: 1
+doc: 1 frequency: 2
 doc: 2 frequency: 1
 doc: 3 frequency: 1
 doc: 4 frequency: 1
-doc: 5 frequency: 1
+doc: 5 frequency: 2
 doc: 6 frequency: 1
 doc: 7 frequency: 1
 doc: 8 frequency: 1
@@ -1328,85 +2098,19 @@ doc: 16 frequency: 1
 doc: 17 frequency: 1
 doc: 18 frequency: 1
 doc: 19 frequency: 1
-doc: 20 frequency: 1
-doc: 21 frequency: 1
-doc: 22 frequency: 1
-doc: 23 frequency: 1
-doc: 24 frequency: 1
-doc: 25 frequency: 1
-doc: 26 frequency: 1
-doc: 27 frequency: 1
-doc: 28 frequency: 1
-doc: 29 frequency: 1
-doc: 30 frequency: 1
-
-from:
-doc: 0 frequency: 1
-doc: 1 frequency: 1
-doc: 2 frequency: 1
-doc: 3 frequency: 3
-doc: 4 frequency: 1
-doc: 5 frequency: 1
-doc: 6 frequency: 2
-doc: 7 frequency: 1
-doc: 8 frequency: 1
-doc: 9 frequency: 1
-doc: 10 frequency: 3
-doc: 11 frequency: 1
-doc: 12 frequency: 3
-doc: 13 frequency: 4
-doc: 14 frequency: 1
-doc: 15 frequency: 2
-doc: 16 frequency: 2
-doc: 17 frequency: 2
-doc: 18 frequency: 2
-doc: 19 frequency: 2
 doc: 20 frequency: 1
 doc: 21 frequency: 1
 doc: 22 frequency: 1
 doc: 23 frequency: 1
 doc: 24 frequency: 2
 doc: 25 frequency: 1
-doc: 26 frequency: 3
+doc: 26 frequency: 1
 doc: 27 frequency: 1
-doc: 28 frequency: 5
+doc: 28 frequency: 1
 doc: 29 frequency: 1
 doc: 30 frequency: 1
 
-by:
-doc: 0 frequency: 1
-doc: 1 frequency: 1
-doc: 2 frequency: 2
-doc: 3 frequency: 2
-doc: 4 frequency: 1
-doc: 5 frequency: 2
-doc: 6 frequency: 1
-doc: 7 frequency: 2
-doc: 8 frequency: 3
-doc: 9 frequency: 2
-doc: 10 frequency: 2
-doc: 11 frequency: 2
-doc: 12 frequency: 1
-doc: 13 frequency: 1
-doc: 14 frequency: 1
-doc: 15 frequency: 2
-doc: 16 frequency: 1
-doc: 17 frequency: 2
-doc: 18 frequency: 4
-doc: 19 frequency: 2
-doc: 20 frequency: 1
-doc: 21 frequency: 1
-doc: 22 frequency: 1
-doc: 23 frequency: 3
-doc: 24 frequency: 1
-doc: 25 frequency: 1
-doc: 26 frequency: 1
-doc: 27 frequency: 1
-doc: 28 frequency: 4
-doc: 29 frequency: 1
-doc: 30 frequency: 2
-
-httrack:
+current:
 doc: 0 frequency: 1
 doc: 1 frequency: 1
 doc: 2 frequency: 1
@@ -1439,40 +2143,7 @@ doc: 28 frequency: 1
 doc: 29 frequency: 1
 doc: 30 frequency: 1
 
-website:
-doc: 0 frequency: 1
-doc: 1 frequency: 1
-doc: 2 frequency: 1
-doc: 3 frequency: 1
-doc: 4 frequency: 1
-doc: 5 frequency: 1
-doc: 6 frequency: 3
-doc: 7 frequency: 1
-doc: 8 frequency: 1
-doc: 9 frequency: 1
-doc: 10 frequency: 1
-doc: 11 frequency: 1
-doc: 12 frequency: 1
-doc: 13 frequency: 1
-doc: 14 frequency: 1
-doc: 15 frequency: 1
-doc: 16 frequency: 1
-doc: 17 frequency: 1
-doc: 18 frequency: 1
-doc: 19 frequency: 1
-doc: 20 frequency: 1
-doc: 21 frequency: 1
-doc: 22 frequency: 1
-doc: 23 frequency: 1
-doc: 24 frequency: 1
-doc: 25 frequency: 1
-doc: 26 frequency: 1
-doc: 27 frequency: 1
-doc: 28 frequency: 1
-doc: 29 frequency: 1
-doc: 30 frequency: 1
-
-nov:
+search:
 doc: 0 frequency: 1
 doc: 1 frequency: 1
 doc: 2 frequency: 1
@@ -1486,7 +2157,7 @@ doc: 9 frequency: 1
 doc: 10 frequency: 1
 doc: 11 frequency: 1
 doc: 12 frequency: 1
-doc: 13 frequency: 1
+doc: 13 frequency: 2
 doc: 14 frequency: 1
 doc: 15 frequency: 1
 doc: 16 frequency: 1
@@ -1499,46 +2170,33 @@ doc: 22 frequency: 1
 doc: 23 frequency: 1
 doc: 24 frequency: 1
 doc: 25 frequency: 1
-doc: 26 frequency: 1
+doc: 26 frequency: 2
 doc: 27 frequency: 1
 doc: 28 frequency: 1
 doc: 29 frequency: 1
 doc: 30 frequency: 1
 
-gmt:
-doc: 0 frequency: 1
-doc: 1 frequency: 1
-doc: 2 frequency: 1
-doc: 3 frequency: 1
-doc: 4 frequency: 1
+armed:
+doc: 1 frequency: 4
 doc: 5 frequency: 1
-doc: 6 frequency: 1
-doc: 7 frequency: 1
-doc: 8 frequency: 1
-doc: 9 frequency: 1
-doc: 10 frequency: 1
-doc: 11 frequency: 1
-doc: 12 frequency: 1
-doc: 13 frequency: 1
-doc: 14 frequency: 1
-doc: 15 frequency: 1
-doc: 16 frequency: 1
-doc: 17 frequency: 1
-doc: 18 frequency: 1
-doc: 19 frequency: 1
-doc: 20 frequency: 1
-doc: 21 frequency: 1
-doc: 22 frequency: 1
-doc: 23 frequency: 1
-doc: 24 frequency: 1
-doc: 25 frequency: 1
-doc: 26 frequency: 1
-doc: 27 frequency: 1
-doc: 28 frequency: 1
-doc: 29 frequency: 1
-doc: 30 frequency: 1
 
 anyways:
+doc: 1 frequency: 2
+
+rx:
+doc: 1 frequency: 1
+
+spd:
+doc: 1 frequency: 1
+
+access:
+doc: 1 frequency: 1
+doc: 6 frequency: 2
+
+mountain:
+doc: 1 frequency: 1
+
+drwilliams:
 doc: 1 frequency: 1
 
 williams:
@@ -1550,27 +2208,12 @@ doc: 3 frequency: 1
 doc: 10 frequency: 3
 doc: 15 frequency: 1
 
-my:
-doc: 1 frequency: 2
-doc: 7 frequency: 5
-doc: 8 frequency: 6
-doc: 11 frequency: 4
-doc: 13 frequency: 4
-doc: 14 frequency: 2
-doc: 16 frequency: 5
-doc: 19 frequency: 6
-doc: 21 frequency: 2
-doc: 24 frequency: 1
-doc: 26 frequency: 1
-doc: 28 frequency: 7
-
-best:
+services:
 doc: 1 frequency: 1
-doc: 5 frequency: 1
-doc: 24 frequency: 1
 
 friends:
 doc: 1 frequency: 1
+doc: 30 frequency: 1
 
 lieutenant:
 doc: 1 frequency: 1
@@ -1583,8 +2226,15 @@ doc: 17 frequency: 1
 doc: 18 frequency: 1
 doc: 28 frequency: 2
 
+city:
+doc: 1 frequency: 1
+
 police:
 doc: 1 frequency: 1
+
+department:
+doc: 1 frequency: 2
+doc: 15 frequency: 1
 
 were:
 doc: 1 frequency: 1
@@ -1613,6 +2263,7 @@ doc: 1 frequency: 1
 
 law:
 doc: 1 frequency: 1
+doc: 16 frequency: 1
 
 enforcement:
 doc: 1 frequency: 1
@@ -1626,45 +2277,14 @@ doc: 1 frequency: 1
 phrase:
 doc: 1 frequency: 1
 
-all:
-doc: 1 frequency: 1
-doc: 2 frequency: 1
-doc: 3 frequency: 1
-doc: 5 frequency: 1
-doc: 6 frequency: 2
-doc: 10 frequency: 1
-doc: 13 frequency: 1
-doc: 14 frequency: 4
-doc: 15 frequency: 1
-doc: 17 frequency: 1
-doc: 18 frequency: 1
-doc: 24 frequency: 1
-doc: 28 frequency: 6
-doc: 29 frequency: 7
-
 person:
 doc: 1 frequency: 3
 
 considered:
 doc: 1 frequency: 3
 
-it:
-doc: 1 frequency: 1
-doc: 3 frequency: 2
-doc: 6 frequency: 1
-doc: 10 frequency: 1
-doc: 11 frequency: 2
-doc: 12 frequency: 1
-doc: 13 frequency: 5
-doc: 17 frequency: 2
-doc: 18 frequency: 2
-doc: 19 frequency: 1
-doc: 20 frequency: 1
-doc: 22 frequency: 1
-doc: 23 frequency: 4
-doc: 24 frequency: 1
-doc: 28 frequency: 7
-doc: 29 frequency: 1
+dangerous:
+doc: 1 frequency: 2
 
 possible:
 doc: 1 frequency: 1
@@ -1683,8 +2303,11 @@ doc: 18 frequency: 2
 doc: 19 frequency: 5
 doc: 23 frequency: 2
 doc: 24 frequency: 1
-doc: 28 frequency: 2
+doc: 28 frequency: 3
 doc: 29 frequency: 2
+
+reasoned:
+doc: 1 frequency: 1
 
 as:
 doc: 1 frequency: 1
@@ -1705,6 +2328,7 @@ doc: 30 frequency: 2
 
 situation:
 doc: 1 frequency: 1
+doc: 5 frequency: 1
 
 involve:
 doc: 1 frequency: 1
@@ -1712,7 +2336,17 @@ doc: 1 frequency: 1
 ccw:
 doc: 1 frequency: 1
 
+concealed:
+doc: 1 frequency: 1
+
+weapons:
+doc: 1 frequency: 1
+
 permit:
+doc: 1 frequency: 1
+doc: 13 frequency: 1
+
+violent:
 doc: 1 frequency: 1
 
 his:
@@ -1731,6 +2365,10 @@ doc: 19 frequency: 1
 doc: 20 frequency: 2
 doc: 28 frequency: 1
 
+yes:
+doc: 1 frequency: 1
+doc: 20 frequency: 1
+
 could:
 doc: 1 frequency: 1
 doc: 10 frequency: 1
@@ -1740,6 +2378,7 @@ doc: 28 frequency: 1
 
 see:
 doc: 1 frequency: 1
+doc: 5 frequency: 1
 doc: 24 frequency: 1
 
 guys:
@@ -1751,8 +2390,14 @@ doc: 15 frequency: 1
 doc: 28 frequency: 1
 doc: 30 frequency: 1
 
-department:
+shoot:
 doc: 1 frequency: 1
+doc: 5 frequency: 1
+
+why:
+doc: 2 frequency: 2
+doc: 11 frequency: 1
+doc: 17 frequency: 1
 
 latest:
 doc: 2 frequency: 2
@@ -1766,11 +2411,39 @@ doc: 2 frequency: 2
 outreach:
 doc: 2 frequency: 2
 
-geodesic:
+program:
+doc: 2 frequency: 3
+doc: 9 frequency: 1
+
+cef:
 doc: 2 frequency: 1
+
+geodesic:
+doc: 2 frequency: 2
+
+charles:
+doc: 2 frequency: 1
+
+fiterman:
+doc: 2 frequency: 1
+
+systems:
+doc: 2 frequency: 1
+doc: 5 frequency: 2
+doc: 13 frequency: 1
+doc: 29 frequency: 1
+
+offense:
+doc: 2 frequency: 1
+doc: 16 frequency: 1
+doc: 18 frequency: 1
+
+baptists:
+doc: 2 frequency: 2
 
 order:
 doc: 2 frequency: 1
+doc: 5 frequency: 1
 
 their:
 doc: 2 frequency: 1
@@ -1794,22 +2467,9 @@ doc: 13 frequency: 1
 reaching:
 doc: 2 frequency: 1
 
-new:
-doc: 2 frequency: 2
-doc: 5 frequency: 1
-doc: 8 frequency: 7
-doc: 14 frequency: 3
-doc: 19 frequency: 2
-doc: 20 frequency: 1
-doc: 21 frequency: 3
-doc: 24 frequency: 1
-doc: 28 frequency: 6
-
-baptists:
-doc: 2 frequency: 1
-
 set:
 doc: 2 frequency: 1
+doc: 24 frequency: 1
 
 up:
 doc: 2 frequency: 1
@@ -1828,19 +2488,18 @@ doc: 2 frequency: 1
 bring:
 doc: 2 frequency: 3
 
-one:
-doc: 2 frequency: 1
-doc: 7 frequency: 1
-doc: 13 frequency: 1
-doc: 19 frequency: 1
-doc: 23 frequency: 1
-doc: 28 frequency: 1
-
 convert:
 doc: 2 frequency: 1
 
+don:
+doc: 2 frequency: 1
+doc: 4 frequency: 2
+doc: 7 frequency: 1
+doc: 24 frequency: 1
+
 pay:
 doc: 2 frequency: 1
+doc: 15 frequency: 1
 
 any:
 doc: 2 frequency: 1
@@ -1858,6 +2517,12 @@ doc: 2 frequency: 1
 doc: 21 frequency: 1
 doc: 23 frequency: 1
 
+years:
+doc: 2 frequency: 1
+doc: 18 frequency: 3
+doc: 24 frequency: 1
+doc: 28 frequency: 1
+
 two:
 doc: 2 frequency: 1
 doc: 5 frequency: 1
@@ -1871,6 +2536,9 @@ doc: 2 frequency: 2
 allowed:
 doc: 2 frequency: 1
 
+quit:
+doc: 2 frequency: 1
+
 three:
 doc: 2 frequency: 1
 
@@ -1881,13 +2549,31 @@ doc: 13 frequency: 1
 doc: 24 frequency: 1
 
 diploma:
-doc: 2 frequency: 1
+doc: 2 frequency: 2
 
 proving:
 doc: 2 frequency: 1
 
+by:
+doc: 2 frequency: 1
+doc: 3 frequency: 1
+doc: 5 frequency: 1
+doc: 7 frequency: 1
+doc: 8 frequency: 2
+doc: 9 frequency: 1
+doc: 10 frequency: 1
+doc: 11 frequency: 1
+doc: 15 frequency: 1
+doc: 17 frequency: 1
+doc: 18 frequency: 3
+doc: 19 frequency: 2
+doc: 23 frequency: 2
+doc: 28 frequency: 3
+doc: 30 frequency: 1
+
 clear:
 doc: 2 frequency: 1
+doc: 6 frequency: 2
 
 biblical:
 doc: 2 frequency: 1
@@ -1900,6 +2586,10 @@ doc: 2 frequency: 1
 doc: 12 frequency: 1
 doc: 13 frequency: 1
 doc: 14 frequency: 1
+
+member:
+doc: 2 frequency: 1
+doc: 18 frequency: 1
 
 only:
 doc: 2 frequency: 1
@@ -1918,12 +2608,25 @@ doc: 14 frequency: 1
 doc: 17 frequency: 1
 doc: 23 frequency: 1
 
-can:
+no:
 doc: 2 frequency: 1
-doc: 5 frequency: 1
+doc: 4 frequency: 3
+doc: 5 frequency: 2
 doc: 6 frequency: 1
+doc: 12 frequency: 3
 doc: 13 frequency: 1
-doc: 15 frequency: 1
+doc: 14 frequency: 2
+doc: 16 frequency: 1
+doc: 17 frequency: 1
+doc: 18 frequency: 1
+doc: 24 frequency: 1
+doc: 28 frequency: 2
+
+rv:
+doc: 2 frequency: 1
+doc: 12 frequency: 1
+doc: 16 frequency: 1
+doc: 18 frequency: 1
 doc: 24 frequency: 1
 
 inflatable:
@@ -1933,20 +2636,44 @@ doc: 16 frequency: 1
 doc: 18 frequency: 1
 doc: 24 frequency: 1
 
+tent:
+doc: 2 frequency: 1
+doc: 12 frequency: 1
+doc: 16 frequency: 1
+doc: 18 frequency: 1
+doc: 24 frequency: 1
+
+legal:
+doc: 3 frequency: 3
+
 advice:
-doc: 3 frequency: 2
+doc: 3 frequency: 4
 doc: 17 frequency: 2
 doc: 28 frequency: 1
+
+phudson:
+doc: 3 frequency: 1
+
+pobox:
+doc: 3 frequency: 1
+
+paul:
+doc: 3 frequency: 1
+doc: 13 frequency: 2
+doc: 15 frequency: 1
+
+hudson:
+doc: 3 frequency: 1
 
 doctor:
 doc: 3 frequency: 5
 
 lawyer:
-doc: 3 frequency: 1
+doc: 3 frequency: 4
 
 at:
 doc: 3 frequency: 1
-doc: 4 frequency: 2
+doc: 4 frequency: 3
 doc: 5 frequency: 1
 doc: 6 frequency: 1
 doc: 12 frequency: 1
@@ -1958,8 +2685,11 @@ doc: 17 frequency: 3
 doc: 18 frequency: 2
 doc: 23 frequency: 2
 doc: 24 frequency: 1
-doc: 28 frequency: 4
+doc: 28 frequency: 5
 doc: 29 frequency: 1
+
+party:
+doc: 3 frequency: 1
 
 conversation:
 doc: 3 frequency: 1
@@ -1989,6 +2719,7 @@ free:
 doc: 3 frequency: 1
 doc: 8 frequency: 1
 doc: 10 frequency: 1
+doc: 13 frequency: 1
 doc: 19 frequency: 1
 doc: 28 frequency: 1
 
@@ -1997,6 +2728,7 @@ doc: 3 frequency: 1
 doc: 5 frequency: 1
 doc: 13 frequency: 1
 doc: 14 frequency: 1
+doc: 16 frequency: 1
 doc: 18 frequency: 3
 doc: 23 frequency: 1
 doc: 28 frequency: 1
@@ -2011,8 +2743,8 @@ doc: 3 frequency: 1
 asked:
 doc: 3 frequency: 1
 doc: 4 frequency: 1
-doc: 7 frequency: 1
-doc: 11 frequency: 2
+doc: 7 frequency: 2
+doc: 11 frequency: 5
 doc: 18 frequency: 1
 doc: 20 frequency: 1
 
@@ -2021,43 +2753,61 @@ doc: 3 frequency: 1
 doc: 23 frequency: 1
 doc: 28 frequency: 1
 
-legal:
-doc: 3 frequency: 1
-
 when:
 doc: 3 frequency: 2
 doc: 13 frequency: 1
 doc: 14 frequency: 2
 doc: 18 frequency: 3
-doc: 23 frequency: 1
+doc: 23 frequency: 2
 doc: 24 frequency: 1
 doc: 26 frequency: 1
 doc: 28 frequency: 1
+
+office:
+doc: 3 frequency: 1
 
 give:
 doc: 3 frequency: 2
 doc: 8 frequency: 1
 doc: 28 frequency: 1
 
+them:
+doc: 3 frequency: 3
+doc: 7 frequency: 1
+
 replied:
 doc: 3 frequency: 1
+doc: 11 frequency: 3
 
 then:
 doc: 3 frequency: 1
 doc: 4 frequency: 1
 doc: 8 frequency: 3
+doc: 10 frequency: 1
+doc: 11 frequency: 4
 doc: 18 frequency: 1
 doc: 28 frequency: 1
+doc: 29 frequency: 1
 
 send:
 doc: 3 frequency: 1
 
-them:
+bill:
 doc: 3 frequency: 2
-doc: 7 frequency: 1
+doc: 9 frequency: 1
+
+shocked:
+doc: 3 frequency: 1
 
 agreed:
 doc: 3 frequency: 1
+
+day:
+doc: 3 frequency: 1
+doc: 11 frequency: 1
+doc: 19 frequency: 3
+doc: 24 frequency: 2
+doc: 28 frequency: 2
 
 still:
 doc: 3 frequency: 1
@@ -2070,9 +2820,16 @@ doc: 3 frequency: 1
 slightly:
 doc: 3 frequency: 1
 
+guilty:
+doc: 3 frequency: 1
+doc: 15 frequency: 1
+
 prepared:
 doc: 3 frequency: 1
-doc: 14 frequency: 1
+doc: 14 frequency: 2
+
+bills:
+doc: 3 frequency: 1
 
 he:
 doc: 3 frequency: 2
@@ -2084,7 +2841,7 @@ doc: 18 frequency: 12
 doc: 19 frequency: 2
 doc: 20 frequency: 1
 doc: 24 frequency: 2
-doc: 28 frequency: 4
+doc: 28 frequency: 5
 
 went:
 doc: 3 frequency: 1
@@ -2095,16 +2852,16 @@ doc: 29 frequency: 1
 
 place:
 doc: 3 frequency: 1
+doc: 18 frequency: 1
 doc: 23 frequency: 1
+
+mailbox:
+doc: 3 frequency: 1
 
 found:
 doc: 3 frequency: 1
 doc: 17 frequency: 3
 doc: 28 frequency: 1
-
-bill:
-doc: 3 frequency: 1
-doc: 9 frequency: 1
 
 accounting:
 doc: 3 frequency: 1
@@ -2113,16 +2870,32 @@ web:
 doc: 3 frequency: 1
 doc: 19 frequency: 2
 
-news:
-doc: 3 frequency: 1
-
 letter:
 doc: 3 frequency: 1
+
+says:
+doc: 3 frequency: 1
+doc: 8 frequency: 2
+doc: 28 frequency: 3
 
 copyright:
 doc: 3 frequency: 1
 
+c:
+doc: 3 frequency: 1
+doc: 5 frequency: 1
+doc: 10 frequency: 1
+doc: 13 frequency: 6
+doc: 17 frequency: 1
+
+accountingweb:
+doc: 3 frequency: 1
+
 rights:
+doc: 3 frequency: 1
+doc: 19 frequency: 1
+
+reserved:
 doc: 3 frequency: 1
 doc: 19 frequency: 1
 
@@ -2131,6 +2904,14 @@ doc: 3 frequency: 1
 
 medium:
 doc: 3 frequency: 1
+doc: 17 frequency: 1
+
+non:
+doc: 3 frequency: 1
+
+commercial:
+doc: 3 frequency: 1
+doc: 6 frequency: 1
 
 purposes:
 doc: 3 frequency: 1
@@ -2144,17 +2925,65 @@ doc: 15 frequency: 1
 attribution:
 doc: 3 frequency: 1
 
+given:
+doc: 3 frequency: 1
+
 birds:
 doc: 4 frequency: 3
 
 bees:
+doc: 4 frequency: 3
+
+enge:
+doc: 4 frequency: 1
+
+tc:
+doc: 4 frequency: 1
+
+umn:
+doc: 4 frequency: 1
+
+edu:
+doc: 4 frequency: 1
+doc: 6 frequency: 1
+doc: 13 frequency: 1
+doc: 16 frequency: 1
+doc: 20 frequency: 1
+doc: 21 frequency: 1
+doc: 24 frequency: 1
+doc: 25 frequency: 1
+doc: 27 frequency: 1
+doc: 28 frequency: 2
+
+aaron:
 doc: 4 frequency: 1
 
 e:
 doc: 4 frequency: 1
+doc: 19 frequency: 3
+
+engelhart:
+doc: 4 frequency: 1
+
+sexual:
+doc: 4 frequency: 1
+doc: 11 frequency: 1
+doc: 20 frequency: 1
+doc: 28 frequency: 1
+
+forwarded:
+doc: 4 frequency: 1
+doc: 14 frequency: 1
+
+morris:
+doc: 4 frequency: 1
+doc: 15 frequency: 1
 
 asks:
 doc: 4 frequency: 1
+
+son:
+doc: 4 frequency: 2
 
 aged:
 doc: 4 frequency: 1
@@ -2164,7 +2993,7 @@ doc: 4 frequency: 1
 
 child:
 doc: 4 frequency: 1
-doc: 7 frequency: 1
+doc: 7 frequency: 4
 
 bursting:
 doc: 4 frequency: 1
@@ -2174,11 +3003,27 @@ doc: 4 frequency: 1
 doc: 9 frequency: 1
 doc: 29 frequency: 1
 
+tears:
+doc: 4 frequency: 1
+
+confused:
+doc: 4 frequency: 1
+
 father:
 doc: 4 frequency: 1
-doc: 16 frequency: 1
+doc: 16 frequency: 2
 
-son:
+wrong:
+doc: 4 frequency: 1
+doc: 29 frequency: 1
+
+oh:
+doc: 4 frequency: 1
+
+dad:
+doc: 4 frequency: 1
+
+sobbed:
 doc: 4 frequency: 1
 
 age:
@@ -2187,12 +3032,11 @@ doc: 4 frequency: 3
 six:
 doc: 4 frequency: 1
 
-no:
+santa:
+doc: 4 frequency: 1
+
+speech:
 doc: 4 frequency: 3
-doc: 5 frequency: 2
-doc: 13 frequency: 1
-doc: 14 frequency: 1
-doc: 17 frequency: 1
 
 seven:
 doc: 4 frequency: 1
@@ -2201,36 +3045,29 @@ easter:
 doc: 4 frequency: 1
 doc: 18 frequency: 1
 
+bunny:
+doc: 4 frequency: 1
+
 hit:
 doc: 4 frequency: 1
 
-me:
-doc: 4 frequency: 2
-doc: 6 frequency: 1
-doc: 7 frequency: 1
-doc: 8 frequency: 1
-doc: 13 frequency: 1
-doc: 16 frequency: 1
-doc: 20 frequency: 1
-doc: 22 frequency: 1
-doc: 25 frequency: 1
-doc: 28 frequency: 4
-
 tooth:
+doc: 4 frequency: 1
+
+fairy:
 doc: 4 frequency: 1
 
 tell:
 doc: 4 frequency: 1
 
-now:
+grown:
 doc: 4 frequency: 1
-doc: 8 frequency: 2
-doc: 10 frequency: 1
-doc: 15 frequency: 1
-doc: 17 frequency: 1
-doc: 19 frequency: 1
-doc: 21 frequency: 1
-doc: 23 frequency: 1
+
+ups:
+doc: 4 frequency: 1
+
+sex:
+doc: 4 frequency: 1
 
 nothing:
 doc: 4 frequency: 1
@@ -2241,25 +3078,93 @@ left:
 doc: 4 frequency: 1
 doc: 6 frequency: 1
 doc: 8 frequency: 1
-doc: 11 frequency: 2
+doc: 11 frequency: 3
 
 live:
 doc: 4 frequency: 1
 
+y:
+doc: 5 frequency: 8
+doc: 24 frequency: 1
+doc: 28 frequency: 27
+doc: 29 frequency: 3
+doc: 30 frequency: 2
+
+k:
+doc: 5 frequency: 8
+doc: 24 frequency: 1
+doc: 28 frequency: 27
+doc: 29 frequency: 3
+doc: 30 frequency: 2
+
 bunker:
-doc: 5 frequency: 5
+doc: 5 frequency: 7
 
 manual:
 doc: 5 frequency: 2
 
 excerpt:
+doc: 5 frequency: 2
+
+bt:
 doc: 5 frequency: 1
+doc: 18 frequency: 1
+
+templetons:
+doc: 5 frequency: 1
+doc: 18 frequency: 1
+
+brad:
+doc: 5 frequency: 2
+doc: 18 frequency: 2
+
+templeton:
+doc: 5 frequency: 1
+doc: 18 frequency: 1
+
+external:
+doc: 5 frequency: 1
+doc: 17 frequency: 1
+doc: 18 frequency: 1
+doc: 19 frequency: 1
+doc: 25 frequency: 1
+doc: 28 frequency: 2
+
+html:
+doc: 5 frequency: 1
+doc: 17 frequency: 2
+doc: 18 frequency: 1
+doc: 19 frequency: 1
+doc: 25 frequency: 1
+doc: 28 frequency: 2
+
+topical:
+doc: 5 frequency: 1
+doc: 18 frequency: 1
+doc: 24 frequency: 3
+doc: 25 frequency: 1
+doc: 26 frequency: 1
+
+original:
+doc: 5 frequency: 1
+doc: 7 frequency: 1
+doc: 8 frequency: 1
+doc: 16 frequency: 1
+doc: 20 frequency: 1
+doc: 21 frequency: 1
 
 manuals:
 doc: 5 frequency: 1
 
 survivalists:
 doc: 5 frequency: 1
+
+once:
+doc: 5 frequency: 2
+doc: 6 frequency: 1
+doc: 14 frequency: 1
+doc: 20 frequency: 1
+doc: 28 frequency: 1
 
 your:
 doc: 5 frequency: 11
@@ -2271,11 +3176,12 @@ doc: 28 frequency: 4
 
 family:
 doc: 5 frequency: 1
-doc: 16 frequency: 1
+doc: 16 frequency: 3
 
 enter:
 doc: 5 frequency: 1
 doc: 6 frequency: 1
+doc: 13 frequency: 1
 
 dec:
 doc: 5 frequency: 1
@@ -2302,6 +3208,13 @@ doc: 13 frequency: 1
 course:
 doc: 5 frequency: 1
 doc: 14 frequency: 1
+doc: 15 frequency: 1
+
+bug:
+doc: 5 frequency: 1
+doc: 28 frequency: 2
+doc: 29 frequency: 1
+doc: 30 frequency: 5
 
 rely:
 doc: 5 frequency: 1
@@ -2318,15 +3231,24 @@ doc: 5 frequency: 1
 doc: 23 frequency: 1
 doc: 25 frequency: 1
 
+fail:
+doc: 5 frequency: 1
+doc: 28 frequency: 1
+
+here:
+doc: 5 frequency: 1
+doc: 8 frequency: 1
+doc: 9 frequency: 1
+doc: 11 frequency: 1
+doc: 15 frequency: 1
+doc: 17 frequency: 1
+doc: 18 frequency: 1
+doc: 28 frequency: 1
+
 worst:
 doc: 5 frequency: 1
 doc: 12 frequency: 1
 doc: 24 frequency: 1
-
-case:
-doc: 5 frequency: 3
-doc: 19 frequency: 1
-doc: 29 frequency: 1
 
 likely:
 doc: 5 frequency: 2
@@ -2343,22 +3265,20 @@ doc: 15 frequency: 1
 collapse:
 doc: 5 frequency: 2
 
-world:
-doc: 5 frequency: 2
-
 civilization:
 doc: 5 frequency: 2
 
 logistic:
 doc: 5 frequency: 1
 
-systems:
-doc: 5 frequency: 1
-doc: 29 frequency: 1
-
 break:
 doc: 5 frequency: 1
 doc: 13 frequency: 1
+
+down:
+doc: 5 frequency: 1
+doc: 11 frequency: 4
+doc: 23 frequency: 1
 
 radio:
 doc: 5 frequency: 1
@@ -2374,6 +3294,15 @@ doc: 13 frequency: 1
 doc: 18 frequency: 1
 doc: 19 frequency: 1
 doc: 28 frequency: 1
+
+air:
+doc: 5 frequency: 1
+doc: 8 frequency: 2
+
+event:
+doc: 5 frequency: 1
+doc: 28 frequency: 2
+doc: 29 frequency: 1
 
 prepare:
 doc: 5 frequency: 1
@@ -2397,12 +3326,6 @@ doc: 5 frequency: 1
 doc: 10 frequency: 1
 doc: 14 frequency: 1
 
-once:
-doc: 5 frequency: 1
-doc: 6 frequency: 1
-doc: 14 frequency: 1
-doc: 20 frequency: 1
-
 venture:
 doc: 5 frequency: 1
 
@@ -2424,6 +3347,10 @@ doc: 5 frequency: 1
 partly:
 doc: 5 frequency: 1
 
+restored:
+doc: 5 frequency: 1
+doc: 6 frequency: 1
+
 trade:
 doc: 5 frequency: 1
 
@@ -2439,19 +3366,33 @@ doc: 5 frequency: 1
 chapter:
 doc: 5 frequency: 1
 
+b:
+doc: 5 frequency: 1
+doc: 8 frequency: 1
+
 minor:
 doc: 5 frequency: 1
 
 problems:
-doc: 5 frequency: 2
+doc: 5 frequency: 3
+doc: 6 frequency: 1
+doc: 16 frequency: 1
 doc: 28 frequency: 1
+doc: 29 frequency: 1
+
+occur:
+doc: 5 frequency: 1
 
 social:
 doc: 5 frequency: 1
 doc: 15 frequency: 1
 
-society:
+brief:
 doc: 5 frequency: 1
+doc: 18 frequency: 1
+
+society:
+doc: 5 frequency: 2
 
 back:
 doc: 5 frequency: 1
@@ -2469,11 +3410,19 @@ doc: 8 frequency: 1
 doc: 13 frequency: 1
 doc: 20 frequency: 1
 
+weeks:
+doc: 5 frequency: 1
+doc: 13 frequency: 1
+doc: 16 frequency: 1
+
 continue:
 doc: 5 frequency: 1
 doc: 24 frequency: 1
 
 arm:
+doc: 5 frequency: 2
+
+yourself:
 doc: 5 frequency: 2
 
 offer:
@@ -2491,13 +3440,18 @@ doc: 5 frequency: 2
 generously:
 doc: 5 frequency: 1
 
+neighbours:
+doc: 5 frequency: 1
+
 use:
 doc: 5 frequency: 2
 doc: 6 frequency: 1
+doc: 10 frequency: 1
 
 help:
 doc: 5 frequency: 1
-doc: 15 frequency: 1
+doc: 8 frequency: 1
+doc: 15 frequency: 2
 
 rebuild:
 doc: 5 frequency: 1
@@ -2537,6 +3491,10 @@ doc: 5 frequency: 1
 
 extreme:
 doc: 5 frequency: 1
+doc: 18 frequency: 1
+
+caution:
+doc: 5 frequency: 1
 
 chance:
 doc: 5 frequency: 1
@@ -2554,17 +3512,6 @@ doc: 28 frequency: 1
 bugs:
 doc: 5 frequency: 1
 
-so:
-doc: 5 frequency: 1
-doc: 8 frequency: 4
-doc: 9 frequency: 1
-doc: 11 frequency: 3
-doc: 13 frequency: 2
-doc: 15 frequency: 1
-doc: 23 frequency: 3
-doc: 24 frequency: 3
-doc: 28 frequency: 2
-
 small:
 doc: 5 frequency: 1
 doc: 8 frequency: 1
@@ -2572,10 +3519,12 @@ doc: 23 frequency: 1
 
 more:
 doc: 5 frequency: 1
+doc: 10 frequency: 2
 doc: 15 frequency: 1
 doc: 18 frequency: 1
 doc: 19 frequency: 1
 doc: 21 frequency: 1
+doc: 28 frequency: 1
 
 broadcast:
 doc: 5 frequency: 1
@@ -2606,15 +3555,6 @@ doc: 5 frequency: 1
 nations:
 doc: 5 frequency: 1
 
-they:
-doc: 5 frequency: 1
-doc: 8 frequency: 2
-doc: 9 frequency: 1
-doc: 10 frequency: 3
-doc: 13 frequency: 2
-doc: 23 frequency: 1
-doc: 24 frequency: 1
-
 broadcasting:
 doc: 5 frequency: 1
 
@@ -2632,6 +3572,7 @@ doc: 5 frequency: 1
 
 business:
 doc: 5 frequency: 1
+doc: 19 frequency: 1
 
 usual:
 doc: 5 frequency: 1
@@ -2640,7 +3581,13 @@ doc: 13 frequency: 1
 control:
 doc: 5 frequency: 1
 doc: 8 frequency: 1
-doc: 23 frequency: 2
+doc: 23 frequency: 3
+
+population:
+doc: 5 frequency: 1
+
+fooled:
+doc: 5 frequency: 1
 
 stay:
 doc: 5 frequency: 1
@@ -2654,6 +3601,9 @@ doc: 28 frequency: 1
 heavy:
 doc: 5 frequency: 1
 
+rationing:
+doc: 5 frequency: 1
+
 parties:
 doc: 5 frequency: 1
 doc: 14 frequency: 1
@@ -2663,22 +3613,56 @@ doc: 5 frequency: 1
 doc: 15 frequency: 1
 doc: 18 frequency: 1
 doc: 19 frequency: 1
+doc: 28 frequency: 2
 
 pretending:
 doc: 5 frequency: 1
 
-shoot:
+well:
 doc: 5 frequency: 1
+doc: 11 frequency: 4
+doc: 13 frequency: 1
+doc: 19 frequency: 1
+doc: 24 frequency: 1
+doc: 28 frequency: 1
 
 kill:
 doc: 5 frequency: 1
 doc: 7 frequency: 1
 
+necessary:
+doc: 5 frequency: 1
+doc: 28 frequency: 2
+
 clean:
 doc: 6 frequency: 2
 
-access:
+website:
+doc: 6 frequency: 3
+
+sehlat:
 doc: 6 frequency: 1
+
+uclink:
+doc: 6 frequency: 1
+
+berkeley:
+doc: 6 frequency: 1
+
+geoffrey:
+doc: 6 frequency: 1
+
+kidd:
+doc: 6 frequency: 1
+
+computers:
+doc: 6 frequency: 1
+doc: 7 frequency: 1
+doc: 9 frequency: 1
+doc: 17 frequency: 1
+doc: 21 frequency: 1
+doc: 26 frequency: 1
+doc: 30 frequency: 1
 
 sent:
 doc: 6 frequency: 1
@@ -2698,35 +3682,60 @@ message:
 doc: 6 frequency: 1
 doc: 28 frequency: 1
 
-commercial:
-doc: 6 frequency: 1
-
 id:
 doc: 6 frequency: 1
 
 number:
 doc: 6 frequency: 1
+doc: 8 frequency: 3
+doc: 14 frequency: 1
 doc: 15 frequency: 1
+
+doesn:
+doc: 6 frequency: 1
+doc: 13 frequency: 1
 
 work:
 doc: 6 frequency: 1
 doc: 15 frequency: 1
-doc: 23 frequency: 1
+doc: 23 frequency: 2
 doc: 29 frequency: 1
 
+computer:
+doc: 6 frequency: 5
+doc: 21 frequency: 3
+
 sequence:
+doc: 6 frequency: 2
+
+changed:
 doc: 6 frequency: 1
+doc: 15 frequency: 1
 
 numbers:
 doc: 6 frequency: 2
-doc: 8 frequency: 1
+doc: 8 frequency: 2
+
+reversed:
+doc: 6 frequency: 1
 
 space:
 doc: 6 frequency: 1
 
+end:
+doc: 6 frequency: 1
+doc: 19 frequency: 1
+doc: 28 frequency: 1
+
+etc:
+doc: 6 frequency: 3
+doc: 17 frequency: 1
+doc: 19 frequency: 1
+
 problem:
 doc: 6 frequency: 1
 doc: 8 frequency: 1
+doc: 22 frequency: 1
 
 occurred:
 doc: 6 frequency: 1
@@ -2745,16 +3754,47 @@ click:
 doc: 6 frequency: 6
 doc: 17 frequency: 1
 
+options:
+doc: 6 frequency: 1
+
+network:
+doc: 6 frequency: 1
+
+preferences:
+doc: 6 frequency: 1
+
+cache:
+doc: 6 frequency: 2
+
+memory:
+doc: 6 frequency: 1
+
+disk:
+doc: 6 frequency: 1
+doc: 13 frequency: 1
+
+okay:
+doc: 6 frequency: 1
+doc: 11 frequency: 1
+
 close:
 doc: 6 frequency: 1
 doc: 23 frequency: 1
 
+files:
+doc: 6 frequency: 1
+doc: 29 frequency: 1
+
 shut:
 doc: 6 frequency: 1
 
-computer:
-doc: 6 frequency: 4
-doc: 21 frequency: 1
+completely:
+doc: 6 frequency: 1
+
+start:
+doc: 6 frequency: 1
+doc: 17 frequency: 2
+doc: 28 frequency: 1
 
 carefully:
 doc: 6 frequency: 1
@@ -2762,9 +3802,25 @@ doc: 23 frequency: 1
 
 code:
 doc: 6 frequency: 1
+doc: 29 frequency: 1
+
+spaces:
+doc: 6 frequency: 1
+
+otherwise:
+doc: 6 frequency: 1
 
 procedure:
 doc: 6 frequency: 2
+
+again:
+doc: 6 frequency: 1
+doc: 11 frequency: 2
+doc: 14 frequency: 1
+doc: 29 frequency: 1
+
+initially:
+doc: 6 frequency: 1
 
 seem:
 doc: 6 frequency: 1
@@ -2775,20 +3831,21 @@ doc: 6 frequency: 1
 
 until:
 doc: 6 frequency: 1
-doc: 18 frequency: 1
+doc: 18 frequency: 2
 doc: 28 frequency: 2
 doc: 30 frequency: 1
-
-cache:
-doc: 6 frequency: 1
-
-restored:
-doc: 6 frequency: 1
 
 normally:
 doc: 6 frequency: 1
 
 accessed:
+doc: 6 frequency: 1
+doc: 13 frequency: 1
+
+images:
+doc: 6 frequency: 1
+
+important:
 doc: 6 frequency: 1
 
 hammer:
@@ -2796,6 +3853,8 @@ doc: 6 frequency: 1
 
 please:
 doc: 6 frequency: 1
+doc: 14 frequency: 1
+doc: 19 frequency: 1
 
 save:
 doc: 6 frequency: 1
@@ -2810,16 +3869,39 @@ doc: 6 frequency: 1
 
 since:
 doc: 6 frequency: 1
+doc: 15 frequency: 1
 doc: 21 frequency: 1
 
 solves:
 doc: 6 frequency: 1
+
+many:
+doc: 6 frequency: 1
+doc: 8 frequency: 1
+doc: 15 frequency: 1
+doc: 19 frequency: 1
 
 mystifying:
 doc: 6 frequency: 1
 
 related:
 doc: 6 frequency: 1
+doc: 15 frequency: 1
+
+processes:
+doc: 7 frequency: 3
+
+iam:
+doc: 7 frequency: 1
+
+bryanross:
+doc: 7 frequency: 1
+
+bryan:
+doc: 7 frequency: 1
+
+ross:
+doc: 7 frequency: 1
 
 surfing:
 doc: 7 frequency: 1
@@ -2832,6 +3914,8 @@ doc: 7 frequency: 1
 
 clothing:
 doc: 7 frequency: 1
+doc: 15 frequency: 1
+doc: 23 frequency: 1
 
 outlet:
 doc: 7 frequency: 1
@@ -2845,10 +3929,21 @@ doc: 7 frequency: 1
 
 kids:
 doc: 7 frequency: 1
+doc: 19 frequency: 1
+
+shirt:
+doc: 7 frequency: 2
+doc: 14 frequency: 1
+
+process:
+doc: 7 frequency: 1
 
 across:
 doc: 7 frequency: 1
 doc: 28 frequency: 1
+
+front:
+doc: 7 frequency: 1
 
 credit:
 doc: 7 frequency: 1
@@ -2856,7 +3951,7 @@ doc: 8 frequency: 1
 
 card:
 doc: 7 frequency: 1
-doc: 8 frequency: 4
+doc: 8 frequency: 6
 doc: 28 frequency: 1
 
 starting:
@@ -2872,6 +3967,9 @@ doc: 7 frequency: 1
 doc: 8 frequency: 1
 doc: 14 frequency: 1
 
+daughters:
+doc: 7 frequency: 1
+
 wife:
 doc: 7 frequency: 1
 doc: 11 frequency: 1
@@ -2883,19 +3981,21 @@ doc: 7 frequency: 1
 doc: 11 frequency: 1
 doc: 14 frequency: 1
 
+buying:
+doc: 7 frequency: 1
+doc: 19 frequency: 1
+
 showed:
 doc: 7 frequency: 1
 
 her:
 doc: 7 frequency: 2
 doc: 8 frequency: 1
-doc: 11 frequency: 7
+doc: 11 frequency: 9
 doc: 19 frequency: 1
+doc: 28 frequency: 1
 
 picture:
-doc: 7 frequency: 1
-
-shirt:
 doc: 7 frequency: 1
 
 she:
@@ -2910,7 +4010,8 @@ doc: 7 frequency: 1
 
 head:
 doc: 7 frequency: 1
-doc: 11 frequency: 1
+doc: 11 frequency: 2
+doc: 19 frequency: 1
 
 routinely:
 doc: 7 frequency: 1
@@ -2941,17 +4042,49 @@ doc: 7 frequency: 1
 reading:
 doc: 7 frequency: 1
 
+story:
+doc: 7 frequency: 1
+doc: 13 frequency: 1
+
+high:
+doc: 8 frequency: 2
+doc: 10 frequency: 1
+doc: 13 frequency: 1
+doc: 16 frequency: 1
+
 finance:
 doc: 8 frequency: 2
 
 modern:
 doc: 8 frequency: 2
+doc: 15 frequency: 1
 
 era:
+doc: 8 frequency: 2
+
+johnl:
 doc: 8 frequency: 1
+
+iecc:
+doc: 8 frequency: 1
+
+john:
+doc: 8 frequency: 2
 
 r:
 doc: 8 frequency: 1
+
+levine:
+doc: 8 frequency: 1
+
+chuckle:
+doc: 8 frequency: 1
+doc: 9 frequency: 1
+doc: 11 frequency: 1
+doc: 18 frequency: 1
+doc: 19 frequency: 1
+doc: 23 frequency: 1
+doc: 27 frequency: 1
 
 someone:
 doc: 8 frequency: 1
@@ -2974,6 +4107,9 @@ doc: 8 frequency: 1
 conference:
 doc: 8 frequency: 1
 
+registration:
+doc: 8 frequency: 1
+
 explained:
 doc: 8 frequency: 1
 
@@ -2987,22 +4123,26 @@ gave:
 doc: 8 frequency: 1
 doc: 29 frequency: 1
 
+isn:
+doc: 8 frequency: 1
+doc: 14 frequency: 1
+
 cooperating:
 doc: 8 frequency: 1
 
 charge:
 doc: 8 frequency: 1
 
-says:
-doc: 8 frequency: 2
-doc: 28 frequency: 2
+terminal:
+doc: 8 frequency: 1
 
 bad:
 doc: 8 frequency: 1
+doc: 11 frequency: 1
 doc: 15 frequency: 2
 
-account:
-doc: 8 frequency: 2
+yeah:
+doc: 8 frequency: 1
 
 because:
 doc: 8 frequency: 2
@@ -3010,21 +4150,26 @@ doc: 13 frequency: 1
 doc: 16 frequency: 1
 doc: 29 frequency: 1
 
-continental:
+co:
+doc: 8 frequency: 5
+doc: 9 frequency: 2
+doc: 30 frequency: 1
+
+branded:
 doc: 8 frequency: 4
 
+continental:
+doc: 8 frequency: 6
+
 airlines:
-doc: 8 frequency: 2
+doc: 8 frequency: 3
 
 successor:
 doc: 8 frequency: 4
 
 texas:
 doc: 8 frequency: 1
-doc: 24 frequency: 4
-
-air:
-doc: 8 frequency: 1
+doc: 24 frequency: 5
 
 corporation:
 doc: 8 frequency: 1
@@ -3036,14 +4181,26 @@ doc: 18 frequency: 1
 subsidiaries:
 doc: 8 frequency: 1
 
+peopleexpress:
+doc: 8 frequency: 1
+
+provincetown:
+doc: 8 frequency: 1
+
+boston:
+doc: 8 frequency: 1
+
+airline:
+doc: 8 frequency: 1
+
 marine:
 doc: 8 frequency: 2
 
 midland:
-doc: 8 frequency: 1
+doc: 8 frequency: 2
 
 bank:
-doc: 8 frequency: 9
+doc: 8 frequency: 11
 doc: 28 frequency: 2
 
 indirect:
@@ -3064,23 +4221,30 @@ doc: 8 frequency: 1
 banking:
 doc: 8 frequency: 1
 
+corp:
+doc: 8 frequency: 3
+
 renamed:
 doc: 8 frequency: 3
 
 hsbc:
 doc: 8 frequency: 1
 
+usa:
+doc: 8 frequency: 1
+doc: 10 frequency: 1
+
 master:
 doc: 8 frequency: 1
 
 visa:
-doc: 8 frequency: 2
+doc: 8 frequency: 4
 
 sold:
 doc: 8 frequency: 2
 
 chase:
-doc: 8 frequency: 2
+doc: 8 frequency: 5
 
 manhattan:
 doc: 8 frequency: 2
@@ -3092,7 +4256,7 @@ bought:
 doc: 8 frequency: 2
 
 itself:
-doc: 8 frequency: 2
+doc: 8 frequency: 3
 
 better:
 doc: 8 frequency: 2
@@ -3114,6 +4278,7 @@ doc: 8 frequency: 2
 
 later:
 doc: 8 frequency: 1
+doc: 18 frequency: 1
 
 cancelled:
 doc: 8 frequency: 1
@@ -3123,6 +4288,7 @@ doc: 8 frequency: 1
 
 another:
 doc: 8 frequency: 1
+doc: 19 frequency: 1
 doc: 24 frequency: 1
 
 other:
@@ -3143,11 +4309,30 @@ doc: 8 frequency: 1
 ahold:
 doc: 8 frequency: 1
 
+v:
+doc: 8 frequency: 1
+doc: 13 frequency: 1
+
+netherlands:
+doc: 8 frequency: 1
+
+m:
+doc: 8 frequency: 5
+doc: 13 frequency: 1
+doc: 14 frequency: 2
+doc: 20 frequency: 1
+doc: 21 frequency: 1
+doc: 24 frequency: 5
+doc: 25 frequency: 1
+
+merchants:
+doc: 8 frequency: 1
+
 traders:
 doc: 8 frequency: 1
 
 formerly:
-doc: 8 frequency: 5
+doc: 8 frequency: 7
 doc: 18 frequency: 1
 
 empire:
@@ -3161,6 +4346,10 @@ doc: 28 frequency: 1
 
 dropped:
 doc: 8 frequency: 1
+
+brand:
+doc: 8 frequency: 1
+doc: 23 frequency: 1
 
 became:
 doc: 8 frequency: 1
@@ -3181,13 +4370,10 @@ holding:
 doc: 8 frequency: 1
 doc: 19 frequency: 1
 
-company:
-doc: 8 frequency: 1
-doc: 15 frequency: 1
-doc: 19 frequency: 1
-doc: 28 frequency: 1
-
 maryland:
+doc: 8 frequency: 1
+
+n:
 doc: 8 frequency: 1
 
 even:
@@ -3197,6 +4383,8 @@ doc: 18 frequency: 2
 
 though:
 doc: 8 frequency: 1
+doc: 12 frequency: 1
+doc: 19 frequency: 1
 doc: 28 frequency: 1
 
 say:
@@ -3216,12 +4404,19 @@ doc: 8 frequency: 1
 
 year:
 doc: 8 frequency: 1
-doc: 14 frequency: 2
+doc: 14 frequency: 3
 doc: 18 frequency: 2
 doc: 21 frequency: 1
-doc: 28 frequency: 2
+doc: 24 frequency: 1
+doc: 28 frequency: 7
 
 discontinued:
+doc: 8 frequency: 1
+
+airport:
+doc: 8 frequency: 1
+
+ithaca:
 doc: 8 frequency: 1
 
 miles:
@@ -3250,8 +4445,15 @@ doc: 25 frequency: 1
 doc: 28 frequency: 2
 doc: 30 frequency: 1
 
+syracuse:
+doc: 8 frequency: 1
+
 half:
 doc: 8 frequency: 1
+
+away:
+doc: 8 frequency: 2
+doc: 14 frequency: 1
 
 elmira:
 doc: 8 frequency: 1
@@ -3259,11 +4461,18 @@ doc: 8 frequency: 1
 binghamton:
 doc: 8 frequency: 1
 
+aren:
+doc: 8 frequency: 1
+doc: 10 frequency: 1
+
 served:
 doc: 8 frequency: 2
 
 northwest:
 doc: 8 frequency: 2
+
+orient:
+doc: 8 frequency: 1
 
 republic:
 doc: 8 frequency: 1
@@ -3271,12 +4480,16 @@ doc: 8 frequency: 1
 hughes:
 doc: 8 frequency: 1
 
+airwest:
+doc: 8 frequency: 1
+
 exchanges:
 doc: 8 frequency: 1
 
 through:
 doc: 8 frequency: 1
-doc: 13 frequency: 1
+doc: 10 frequency: 1
+doc: 13 frequency: 2
 doc: 14 frequency: 1
 
 voting:
@@ -3300,9 +4513,6 @@ doc: 8 frequency: 1
 doc: 10 frequency: 1
 doc: 13 frequency: 1
 doc: 19 frequency: 1
-
-away:
-doc: 8 frequency: 1
 
 connect:
 doc: 8 frequency: 1
@@ -3328,10 +4538,28 @@ doc: 8 frequency: 1
 
 hours:
 doc: 8 frequency: 1
+doc: 15 frequency: 1
 doc: 18 frequency: 2
 doc: 19 frequency: 1
+doc: 29 frequency: 1
+
+winter:
+doc: 8 frequency: 1
+doc: 14 frequency: 1
 
 usairways:
+doc: 8 frequency: 1
+
+usair:
+doc: 8 frequency: 1
+
+allegheny:
+doc: 8 frequency: 1
+
+piedmont:
+doc: 8 frequency: 1
+
+mohawk:
 doc: 8 frequency: 1
 
 variety:
@@ -3343,18 +4571,37 @@ doc: 8 frequency: 1
 nationsbank:
 doc: 8 frequency: 2
 
-many:
+mid:
 doc: 8 frequency: 1
-doc: 15 frequency: 1
-doc: 19 frequency: 1
+
+atlantic:
+doc: 8 frequency: 1
+
+banks:
+doc: 8 frequency: 1
+doc: 28 frequency: 1
+
+bankamerica:
+doc: 8 frequency: 1
 
 italy:
 doc: 8 frequency: 1
 
+did:
+doc: 8 frequency: 1
+doc: 11 frequency: 2
+doc: 13 frequency: 1
+
 east:
 doc: 8 frequency: 1
 
+coast:
+doc: 8 frequency: 1
+
 exp:
+doc: 8 frequency: 1
+
+questions:
 doc: 8 frequency: 1
 
 feel:
@@ -3362,7 +4609,31 @@ doc: 8 frequency: 1
 doc: 19 frequency: 1
 doc: 28 frequency: 1
 
+ask:
+doc: 8 frequency: 1
+
+buggy:
+doc: 9 frequency: 2
+
 debugging:
+doc: 9 frequency: 2
+
+luke:
+doc: 9 frequency: 2
+
+staff:
+doc: 9 frequency: 1
+
+ihug:
+doc: 9 frequency: 2
+
+nz:
+doc: 9 frequency: 2
+
+pascoe:
+doc: 9 frequency: 1
+
+whilst:
 doc: 9 frequency: 1
 
 watching:
@@ -3374,10 +4645,15 @@ doc: 9 frequency: 1
 box:
 doc: 9 frequency: 1
 
+yesterday:
+doc: 9 frequency: 1
+doc: 17 frequency: 1
+doc: 19 frequency: 1
+
 dna:
 doc: 9 frequency: 2
 
-program:
+run:
 doc: 9 frequency: 1
 
 gates:
@@ -3388,7 +4664,7 @@ doc: 9 frequency: 1
 
 million:
 doc: 9 frequency: 1
-doc: 19 frequency: 2
+doc: 19 frequency: 3
 
 interviewed:
 doc: 9 frequency: 1
@@ -3417,18 +4693,32 @@ doc: 13 frequency: 1
 doc: 18 frequency: 3
 doc: 19 frequency: 1
 doc: 20 frequency: 1
-doc: 28 frequency: 1
+doc: 28 frequency: 2
+
+software:
+doc: 9 frequency: 1
+
+afraid:
+doc: 9 frequency: 1
 
 originally:
 doc: 9 frequency: 1
 
 mark:
 doc: 9 frequency: 1
+doc: 27 frequency: 1
+doc: 28 frequency: 1
 
 denholm:
 doc: 9 frequency: 1
 
+gigs:
+doc: 9 frequency: 1
+
 posted:
+doc: 9 frequency: 1
+
+permission:
 doc: 9 frequency: 1
 
 insert:
@@ -3436,6 +4726,9 @@ doc: 9 frequency: 1
 doc: 28 frequency: 1
 
 favorite:
+doc: 9 frequency: 1
+
+bsod:
 doc: 9 frequency: 1
 
 gpf:
@@ -3447,16 +4740,22 @@ doc: 9 frequency: 1
 operation:
 doc: 9 frequency: 1
 
-here:
-doc: 9 frequency: 1
-doc: 11 frequency: 1
-doc: 15 frequency: 1
-doc: 18 frequency: 1
-
-text:
+susie:
 doc: 10 frequency: 2
 
-humor:
+cleland:
+doc: 10 frequency: 2
+
+hotmail:
+doc: 10 frequency: 1
+doc: 22 frequency: 1
+
+true:
+doc: 10 frequency: 1
+doc: 26 frequency: 1
+doc: 28 frequency: 1
+
+doctors:
 doc: 10 frequency: 1
 
 veterinarians:
@@ -3469,6 +4768,16 @@ doc: 18 frequency: 1
 knowing:
 doc: 10 frequency: 1
 
+fifty:
+doc: 10 frequency: 1
+
+dollar:
+doc: 10 frequency: 1
+
+words:
+doc: 10 frequency: 2
+doc: 18 frequency: 1
+
 whole:
 doc: 10 frequency: 1
 
@@ -3478,24 +4787,35 @@ doc: 10 frequency: 1
 devoted:
 doc: 10 frequency: 1
 
+terminology:
+doc: 10 frequency: 1
+
+dry:
+doc: 10 frequency: 1
+
 staid:
 doc: 10 frequency: 1
 
 lists:
 doc: 10 frequency: 1
 
-words:
+definitions:
 doc: 10 frequency: 1
-doc: 18 frequency: 1
 
 bit:
 doc: 10 frequency: 1
 doc: 14 frequency: 1
 
+authors:
+doc: 10 frequency: 1
+
 personality:
 doc: 10 frequency: 1
 
 shows:
+doc: 10 frequency: 1
+
+bailliere:
 doc: 10 frequency: 1
 
 comprehensive:
@@ -3504,10 +4824,20 @@ doc: 10 frequency: 1
 veterinary:
 doc: 10 frequency: 1
 
+dictionary:
+doc: 10 frequency: 1
+
+d:
+doc: 10 frequency: 1
+doc: 14 frequency: 4
+doc: 17 frequency: 1
+doc: 24 frequency: 1
+doc: 28 frequency: 2
+
 blood:
 doc: 10 frequency: 1
 
-virginia:
+studdert:
 doc: 10 frequency: 1
 
 following:
@@ -3526,12 +4856,12 @@ doc: 30 frequency: 1
 page:
 doc: 10 frequency: 1
 doc: 15 frequency: 1
-doc: 19 frequency: 3
+doc: 19 frequency: 4
 doc: 28 frequency: 1
 
 right:
 doc: 10 frequency: 1
-doc: 11 frequency: 2
+doc: 11 frequency: 3
 doc: 13 frequency: 1
 doc: 28 frequency: 2
 
@@ -3539,10 +4869,25 @@ between:
 doc: 10 frequency: 1
 doc: 13 frequency: 1
 
+brunner:
+doc: 10 frequency: 1
+
 glands:
 doc: 10 frequency: 1
 
 brush:
+doc: 10 frequency: 1
+
+border:
+doc: 10 frequency: 1
+
+brunus:
+doc: 10 frequency: 1
+
+edwardii:
+doc: 10 frequency: 1
+
+urban:
 doc: 10 frequency: 1
 
 companion:
@@ -3551,6 +4896,9 @@ doc: 10 frequency: 1
 animal:
 doc: 10 frequency: 1
 doc: 17 frequency: 1
+
+bear:
+doc: 10 frequency: 2
 
 admired:
 doc: 10 frequency: 1
@@ -3569,12 +4917,11 @@ doc: 10 frequency: 1
 house:
 doc: 10 frequency: 1
 doc: 12 frequency: 1
+doc: 14 frequency: 1
 doc: 28 frequency: 1
 
-high:
+training:
 doc: 10 frequency: 1
-doc: 13 frequency: 1
-doc: 16 frequency: 1
 
 emotional:
 doc: 10 frequency: 1
@@ -3589,6 +4936,9 @@ doc: 15 frequency: 1
 freedom:
 doc: 10 frequency: 1
 
+disease:
+doc: 10 frequency: 2
+
 called:
 doc: 10 frequency: 1
 
@@ -3598,14 +4948,18 @@ doc: 10 frequency: 1
 theodorus:
 doc: 10 frequency: 1
 
+pooh:
+doc: 10 frequency: 1
+
 paddington:
 doc: 10 frequency: 1
 
 brideshead:
 doc: 10 frequency: 1
 
-bear:
+uk:
 doc: 10 frequency: 1
+doc: 30 frequency: 1
 
 add:
 doc: 10 frequency: 1
@@ -3622,12 +4976,30 @@ doc: 10 frequency: 1
 surgical:
 doc: 10 frequency: 1
 
+repair:
+doc: 10 frequency: 1
+
 things:
 doc: 11 frequency: 7
 doc: 27 frequency: 3
 
+explain:
+doc: 11 frequency: 7
+
+henry:
+doc: 11 frequency: 2
+
+nhcc:
+doc: 11 frequency: 1
+
+w:
+doc: 11 frequency: 1
+
+farkas:
+doc: 11 frequency: 1
+
 farmer:
-doc: 11 frequency: 8
+doc: 11 frequency: 10
 
 neighborhood:
 doc: 11 frequency: 1
@@ -3638,18 +5010,27 @@ doc: 11 frequency: 1
 getting:
 doc: 11 frequency: 2
 
+hammered:
+doc: 11 frequency: 1
+
 man:
-doc: 11 frequency: 7
+doc: 11 frequency: 8
+doc: 14 frequency: 1
 
 came:
 doc: 11 frequency: 1
 doc: 18 frequency: 1
 
-why:
+hey:
 doc: 11 frequency: 1
-doc: 17 frequency: 1
+doc: 15 frequency: 1
+doc: 18 frequency: 1
+doc: 25 frequency: 1
 
 beautiful:
+doc: 11 frequency: 1
+
+drunk:
 doc: 11 frequency: 1
 
 shook:
@@ -3657,19 +5038,36 @@ doc: 11 frequency: 1
 
 happened:
 doc: 11 frequency: 2
+doc: 29 frequency: 1
+
+horrible:
+doc: 11 frequency: 1
 
 sat:
 doc: 11 frequency: 3
 
-down:
-doc: 11 frequency: 4
-doc: 23 frequency: 1
+today:
+doc: 11 frequency: 1
+doc: 17 frequency: 1
+doc: 22 frequency: 1
+doc: 26 frequency: 1
+doc: 28 frequency: 3
+
+cow:
+doc: 11 frequency: 2
 
 milking:
 doc: 11 frequency: 2
 
 bucket:
-doc: 11 frequency: 4
+doc: 11 frequency: 6
+
+bout:
+doc: 11 frequency: 2
+
+full:
+doc: 11 frequency: 3
+doc: 15 frequency: 1
 
 lifted:
 doc: 11 frequency: 1
@@ -3697,20 +5095,19 @@ doc: 11 frequency: 1
 laughed:
 doc: 11 frequency: 1
 
-did:
-doc: 11 frequency: 2
-doc: 13 frequency: 1
-
 began:
 doc: 11 frequency: 1
 
 stupid:
 doc: 11 frequency: 1
 
-cow:
+knocked:
 doc: 11 frequency: 1
 
-knocked:
+tail:
+doc: 11 frequency: 2
+
+hmmm:
 doc: 11 frequency: 1
 
 nodded:
@@ -3719,29 +5116,59 @@ doc: 11 frequency: 1
 anymore:
 doc: 11 frequency: 1
 
+rope:
+doc: 11 frequency: 1
+
 belt:
 doc: 11 frequency: 1
 
-tail:
+rafter:
 doc: 11 frequency: 1
+
+moment:
+doc: 11 frequency: 1
+doc: 18 frequency: 1
 
 pants:
 doc: 11 frequency: 1
-doc: 28 frequency: 1
+doc: 19 frequency: 1
+doc: 28 frequency: 2
 
 fell:
 doc: 11 frequency: 1
 doc: 18 frequency: 1
 
-subject:
+provided:
 doc: 12 frequency: 2
+
+aardvark:
+doc: 12 frequency: 1
+
+vcn:
+doc: 12 frequency: 1
+
+bc:
+doc: 12 frequency: 1
+
+hugh:
+doc: 12 frequency: 1
+
+brown:
+doc: 12 frequency: 1
+
+sick:
+doc: 12 frequency: 1
 doc: 24 frequency: 1
 
-provided:
+sock:
 doc: 12 frequency: 1
 
 vj:
 doc: 12 frequency: 1
+
+music:
+doc: 12 frequency: 2
+doc: 17 frequency: 2
 
 hosting:
 doc: 12 frequency: 1
@@ -3749,9 +5176,6 @@ doc: 12 frequency: 1
 survey:
 doc: 12 frequency: 1
 doc: 24 frequency: 1
-
-music:
-doc: 12 frequency: 1
 
 videos:
 doc: 12 frequency: 1
@@ -3761,6 +5185,10 @@ doc: 12 frequency: 1
 
 poison:
 doc: 12 frequency: 1
+
+pain:
+doc: 12 frequency: 1
+doc: 18 frequency: 1
 
 milli:
 doc: 12 frequency: 2
@@ -3775,6 +5203,12 @@ cheesiest:
 doc: 12 frequency: 1
 
 band:
+doc: 12 frequency: 1
+
+sadly:
+doc: 12 frequency: 1
+
+rob:
 doc: 12 frequency: 1
 
 committed:
@@ -3795,21 +5229,58 @@ doc: 12 frequency: 1
 sang:
 doc: 12 frequency: 1
 
-michael:
+album:
 doc: 12 frequency: 1
 
-properties:
+actually:
+doc: 12 frequency: 1
+doc: 13 frequency: 1
+
+lip:
+doc: 12 frequency: 1
+
+synching:
+doc: 12 frequency: 1
+
+michael:
+doc: 12 frequency: 1
+doc: 17 frequency: 1
+
+hutchence:
+doc: 12 frequency: 1
+
+object:
 doc: 13 frequency: 3
 
+properties:
+doc: 13 frequency: 4
+
+ist:
+doc: 13 frequency: 1
+
 flinders:
-doc: 13 frequency: 2
+doc: 13 frequency: 3
+
+au:
+doc: 13 frequency: 1
+doc: 24 frequency: 1
+
+gardner:
+doc: 13 frequency: 1
+
+stephen:
+doc: 13 frequency: 1
 
 university:
 doc: 13 frequency: 1
+doc: 20 frequency: 1
 doc: 24 frequency: 1
 doc: 28 frequency: 1
 
 south:
+doc: 13 frequency: 1
+
+australia:
 doc: 13 frequency: 1
 
 responce:
@@ -3828,10 +5299,24 @@ doc: 13 frequency: 2
 discussion:
 doc: 13 frequency: 2
 
-car:
-doc: 13 frequency: 3
+us:
+doc: 13 frequency: 1
+doc: 19 frequency: 1
+doc: 23 frequency: 1
+doc: 29 frequency: 1
 
-story:
+labf:
+doc: 13 frequency: 2
+
+org:
+doc: 13 frequency: 1
+doc: 24 frequency: 1
+
+car:
+doc: 13 frequency: 5
+doc: 28 frequency: 2
+
+security:
 doc: 13 frequency: 1
 
 begins:
@@ -3842,12 +5327,19 @@ doc: 13 frequency: 1
 doc: 15 frequency: 1
 doc: 24 frequency: 1
 
-weeks:
+ago:
 doc: 13 frequency: 1
 doc: 16 frequency: 1
+doc: 18 frequency: 1
 
 gb:
 doc: 13 frequency: 3
+
+galant:
+doc: 13 frequency: 8
+
+used:
+doc: 13 frequency: 1
 
 lock:
 doc: 13 frequency: 1
@@ -3862,9 +5354,6 @@ doc: 13 frequency: 1
 encourage:
 doc: 13 frequency: 1
 
-actually:
-doc: 13 frequency: 1
-
 window:
 doc: 13 frequency: 1
 
@@ -3876,6 +5365,10 @@ doc: 13 frequency: 1
 doc: 14 frequency: 1
 doc: 19 frequency: 1
 doc: 21 frequency: 2
+
+door:
+doc: 13 frequency: 1
+doc: 15 frequency: 1
 
 worry:
 doc: 13 frequency: 1
@@ -3897,6 +5390,7 @@ doc: 13 frequency: 1
 
 thing:
 doc: 13 frequency: 1
+doc: 28 frequency: 1
 
 spare:
 doc: 13 frequency: 1
@@ -3905,12 +5399,15 @@ oil:
 doc: 13 frequency: 1
 
 brake:
-doc: 13 frequency: 1
+doc: 13 frequency: 2
 
 fluid:
 doc: 13 frequency: 1
 
 boot:
+doc: 13 frequency: 1
+
+trunk:
 doc: 13 frequency: 1
 
 notable:
@@ -3919,22 +5416,28 @@ doc: 13 frequency: 1
 facts:
 doc: 13 frequency: 1
 
-galant:
-doc: 13 frequency: 2
-
 worth:
 doc: 13 frequency: 2
 doc: 28 frequency: 1
 doc: 29 frequency: 1
 
 choke:
-doc: 13 frequency: 5
+doc: 13 frequency: 7
 
 spring:
 doc: 13 frequency: 2
 
+zealous:
+doc: 13 frequency: 1
+
 zeal:
 doc: 13 frequency: 1
+
+especially:
+doc: 13 frequency: 1
+
+summer:
+doc: 13 frequency: 2
 
 previous:
 doc: 13 frequency: 1
@@ -3955,20 +5458,26 @@ doc: 13 frequency: 1
 keeping:
 doc: 13 frequency: 3
 
+required:
+doc: 13 frequency: 2
+
 ash:
-doc: 13 frequency: 1
+doc: 13 frequency: 2
 
 tray:
-doc: 13 frequency: 1
+doc: 13 frequency: 2
 
 contains:
 doc: 13 frequency: 1
+
+piece:
+doc: 13 frequency: 4
 
 coin:
 doc: 13 frequency: 1
 
 size:
-doc: 13 frequency: 1
+doc: 13 frequency: 2
 
 fit:
 doc: 13 frequency: 1
@@ -3988,26 +5497,22 @@ doc: 13 frequency: 1
 
 added:
 doc: 13 frequency: 1
+doc: 24 frequency: 1
 doc: 28 frequency: 2
-
-piece:
-doc: 13 frequency: 3
 
 recently:
 doc: 13 frequency: 1
 doc: 24 frequency: 1
 
-summer:
-doc: 13 frequency: 1
-
 driving:
-doc: 13 frequency: 1
+doc: 13 frequency: 2
 
-night:
+anyway:
 doc: 13 frequency: 1
+doc: 17 frequency: 1
 
 thief:
-doc: 13 frequency: 4
+doc: 13 frequency: 8
 
 decide:
 doc: 13 frequency: 1
@@ -4021,6 +5526,7 @@ doc: 13 frequency: 1
 
 doors:
 doc: 13 frequency: 1
+doc: 23 frequency: 1
 
 rifled:
 doc: 13 frequency: 1
@@ -4033,18 +5539,27 @@ doc: 13 frequency: 1
 doc: 15 frequency: 1
 doc: 17 frequency: 1
 
+money:
+doc: 13 frequency: 1
+doc: 28 frequency: 1
+
 street:
 doc: 13 frequency: 2
 doc: 28 frequency: 1
 
 directory:
-doc: 13 frequency: 1
+doc: 13 frequency: 2
 
 cheap:
 doc: 13 frequency: 1
 
 sunglasses:
 doc: 13 frequency: 1
+
+morning:
+doc: 13 frequency: 1
+doc: 18 frequency: 1
+doc: 28 frequency: 1
 
 adjustments:
 doc: 13 frequency: 1
@@ -4063,9 +5578,6 @@ stole:
 doc: 13 frequency: 1
 
 announcing:
-doc: 13 frequency: 1
-
-labf:
 doc: 13 frequency: 1
 
 various:
@@ -4089,8 +5601,12 @@ doc: 13 frequency: 1
 kilo:
 doc: 13 frequency: 1
 
+volts:
+doc: 13 frequency: 1
+
 large:
 doc: 13 frequency: 1
+doc: 14 frequency: 1
 doc: 17 frequency: 1
 
 dog:
@@ -4110,13 +5626,7 @@ good:
 doc: 13 frequency: 1
 doc: 14 frequency: 1
 
-object:
-doc: 13 frequency: 1
-
 file:
-doc: 13 frequency: 1
-
-disk:
 doc: 13 frequency: 1
 
 operating:
@@ -4127,6 +5637,9 @@ distress:
 doc: 13 frequency: 1
 
 finding:
+doc: 13 frequency: 1
+
+worthless:
 doc: 13 frequency: 1
 
 sentimental:
@@ -4141,7 +5654,10 @@ doc: 13 frequency: 1
 thus:
 doc: 13 frequency: 1
 
-scene:
+formed:
+doc: 13 frequency: 1
+
+act:
 doc: 13 frequency: 1
 
 wandering:
@@ -4156,10 +5672,20 @@ doc: 13 frequency: 1
 black:
 doc: 13 frequency: 2
 
+including:
+doc: 13 frequency: 1
+doc: 28 frequency: 1
+
 tattered:
 doc: 13 frequency: 1
 
 beanie:
+doc: 13 frequency: 1
+
+fingerless:
+doc: 13 frequency: 1
+
+gloves:
 doc: 13 frequency: 1
 
 glances:
@@ -4174,8 +5700,34 @@ doc: 13 frequency: 1
 toward:
 doc: 13 frequency: 1
 
+soto:
+doc: 13 frequency: 1
+
+voce:
+doc: 13 frequency: 1
+
+allo:
+doc: 13 frequency: 2
+
+ave:
+doc: 13 frequency: 1
+
+ere:
+doc: 13 frequency: 1
+
+alt:
+doc: 13 frequency: 1
+
+name:
+doc: 13 frequency: 1
+doc: 15 frequency: 1
+doc: 19 frequency: 1
+
 chrysler:
 doc: 13 frequency: 1
+
+mm:
+doc: 13 frequency: 2
 
 wheelbase:
 doc: 13 frequency: 1
@@ -4183,7 +5735,17 @@ doc: 13 frequency: 1
 seats:
 doc: 13 frequency: 1
 
+date:
+doc: 13 frequency: 1
+doc: 28 frequency: 1
+
+creation:
+doc: 13 frequency: 1
+
 sept:
+doc: 13 frequency: 1
+
+modified:
 doc: 13 frequency: 1
 
 january:
@@ -4192,10 +5754,49 @@ doc: 14 frequency: 1
 doc: 15 frequency: 1
 doc: 24 frequency: 1
 
+type:
+doc: 13 frequency: 1
+
+plater:
+doc: 13 frequency: 1
+
+bomb:
+doc: 13 frequency: 1
+
 associated:
 doc: 13 frequency: 1
 
+application:
+doc: 13 frequency: 1
+
+contents:
+doc: 13 frequency: 1
+
+x:
+doc: 13 frequency: 10
+
+setting:
+doc: 13 frequency: 2
+
+thongs:
+doc: 13 frequency: 1
+
+towels:
+doc: 13 frequency: 1
+
+blankie:
+doc: 13 frequency: 1
+
+plates:
+doc: 13 frequency: 1
+
+lb:
+doc: 13 frequency: 1
+
 beach:
+doc: 13 frequency: 1
+
+sand:
 doc: 13 frequency: 1
 
 very:
@@ -4212,10 +5813,23 @@ doc: 17 frequency: 1
 vinyl:
 doc: 13 frequency: 1
 
+upholstery:
+doc: 13 frequency: 1
+
+l:
+doc: 13 frequency: 1
+doc: 28 frequency: 1
+
 super:
 doc: 13 frequency: 1
 
 fuel:
+doc: 13 frequency: 1
+
+protected:
+doc: 13 frequency: 1
+
+jack:
 doc: 13 frequency: 1
 
 uni:
@@ -4226,35 +5840,75 @@ doc: 13 frequency: 1
 
 ok:
 doc: 13 frequency: 1
+doc: 28 frequency: 2
 
 apply:
 doc: 13 frequency: 1
 doc: 17 frequency: 1
 
-bloody:
+cancel:
+doc: 13 frequency: 2
+
+sheesh:
 doc: 13 frequency: 1
 
-well:
+sigh:
 doc: 13 frequency: 1
-doc: 19 frequency: 1
+
+bloody:
+doc: 13 frequency: 1
 
 wanders:
 doc: 13 frequency: 1
 
-search:
+looting:
 doc: 13 frequency: 1
-doc: 26 frequency: 1
+
+happy:
+doc: 14 frequency: 3
+doc: 28 frequency: 4
+
+dho:
+doc: 14 frequency: 1
+
+rcn:
+doc: 14 frequency: 1
+
+dave:
+doc: 14 frequency: 1
+
+overbeck:
+doc: 14 frequency: 1
+
+twas:
+doc: 14 frequency: 1
 
 month:
 doc: 14 frequency: 1
+doc: 20 frequency: 1
+doc: 28 frequency: 1
+
+christmas:
+doc: 14 frequency: 1
+doc: 21 frequency: 1
+doc: 24 frequency: 1
 
 garment:
 doc: 14 frequency: 1
 
+blouse:
+doc: 14 frequency: 1
+
 cookies:
+doc: 14 frequency: 2
+
+nibble:
 doc: 14 frequency: 1
 
 eggnog:
+doc: 14 frequency: 1
+
+taste:
 doc: 14 frequency: 1
 
 holiday:
@@ -4264,6 +5918,9 @@ doc: 24 frequency: 2
 straight:
 doc: 14 frequency: 1
 
+waist:
+doc: 14 frequency: 1
+
 scales:
 doc: 14 frequency: 1
 
@@ -4271,7 +5928,13 @@ store:
 doc: 14 frequency: 1
 doc: 28 frequency: 1
 
+less:
+doc: 14 frequency: 1
+
 walk:
+doc: 14 frequency: 1
+
+lumber:
 doc: 14 frequency: 1
 
 thought:
@@ -4298,35 +5961,52 @@ doc: 14 frequency: 1
 nicely:
 doc: 14 frequency: 1
 
+rared:
+doc: 14 frequency: 1
+
 rum:
+doc: 14 frequency: 1
+
+balls:
 doc: 14 frequency: 1
 
 bread:
 doc: 14 frequency: 1
 
+cheese:
+doc: 14 frequency: 1
+
 thank:
 doc: 14 frequency: 1
+doc: 16 frequency: 1
 
 put:
 doc: 14 frequency: 1
 doc: 17 frequency: 1
 doc: 29 frequency: 1
 
+extra:
+doc: 14 frequency: 1
+doc: 28 frequency: 2
+
+husband:
+doc: 14 frequency: 1
+
 old:
 doc: 14 frequency: 1
 doc: 15 frequency: 2
 doc: 29 frequency: 1
 
-again:
-doc: 14 frequency: 1
-
 batle:
 doc: 14 frequency: 1
 
-spend:
+dirt:
 doc: 14 frequency: 1
 
-winter:
+myself:
+doc: 14 frequency: 1
+
+spend:
 doc: 14 frequency: 1
 
 disguised:
@@ -4336,14 +6016,30 @@ sour:
 doc: 14 frequency: 1
 
 cream:
+doc: 14 frequency: 2
+
+dip:
+doc: 14 frequency: 1
+
+fruitcake:
 doc: 14 frequency: 1
 
 cracker:
 doc: 14 frequency: 1
 
+chip:
+doc: 14 frequency: 1
+doc: 22 frequency: 2
+
 must:
 doc: 14 frequency: 1
 doc: 25 frequency: 1
+
+banished:
+doc: 14 frequency: 1
+
+till:
+doc: 14 frequency: 1
 
 additional:
 doc: 14 frequency: 1
@@ -4351,13 +6047,36 @@ doc: 14 frequency: 1
 ounces:
 doc: 14 frequency: 1
 
+vanished:
+doc: 14 frequency: 1
+
+won:
+doc: 14 frequency: 2
+doc: 28 frequency: 1
+
 ice:
+doc: 14 frequency: 1
+doc: 18 frequency: 1
+
+lick:
 doc: 14 frequency: 1
 
 chew:
 doc: 14 frequency: 1
 
 celery:
+doc: 14 frequency: 1
+
+stick:
+doc: 14 frequency: 1
+
+biscuits:
+doc: 14 frequency: 1
+
+cornbread:
+doc: 14 frequency: 1
+
+pie:
 doc: 14 frequency: 1
 
 munch:
@@ -4369,27 +6088,82 @@ doc: 14 frequency: 1
 quietly:
 doc: 14 frequency: 1
 
+cry:
+doc: 14 frequency: 1
+
+hungry:
+doc: 14 frequency: 1
+
+lonesome:
+doc: 14 frequency: 1
+
+bore:
+doc: 14 frequency: 1
+
 unable:
 doc: 14 frequency: 1
 
-happy:
+giggle:
 doc: 14 frequency: 1
-doc: 28 frequency: 3
+
+riot:
+doc: 14 frequency: 1
+
+diet:
+doc: 14 frequency: 1
+doc: 16 frequency: 1
 
 making:
 doc: 14 frequency: 1
 doc: 19 frequency: 1
 
+rounds:
+doc: 14 frequency: 1
+
+unattributed:
+doc: 14 frequency: 1
+
+throwback:
+doc: 15 frequency: 2
+
 days:
-doc: 15 frequency: 1
+doc: 15 frequency: 2
 doc: 18 frequency: 1
+doc: 23 frequency: 1
 doc: 24 frequency: 1
 doc: 28 frequency: 1
+
+tmorris:
+doc: 15 frequency: 1
+
+mailhost:
+doc: 15 frequency: 1
+
+rsn:
+doc: 15 frequency: 1
+
+hp:
+doc: 15 frequency: 2
+
+terry:
+doc: 15 frequency: 1
 
 convex:
 doc: 15 frequency: 1
 
+division:
+doc: 15 frequency: 1
+
+harley:
+doc: 15 frequency: 3
+
+davidson:
+doc: 15 frequency: 2
+
 motor:
+doc: 15 frequency: 2
+
+upscale:
 doc: 15 frequency: 1
 
 dealerships:
@@ -4398,11 +6172,17 @@ doc: 15 frequency: 2
 upgraded:
 doc: 15 frequency: 1
 
+image:
+doc: 15 frequency: 1
+
 greasy:
 doc: 15 frequency: 1
 
 motorcycle:
 doc: 15 frequency: 1
+
+shop:
+doc: 15 frequency: 3
 
 customers:
 doc: 15 frequency: 1
@@ -4411,13 +6191,37 @@ expect:
 doc: 15 frequency: 1
 doc: 24 frequency: 1
 
+boutique:
+doc: 15 frequency: 1
+
+motorcycling:
+doc: 15 frequency: 1
+
+experience:
+doc: 15 frequency: 1
+
 comes:
 doc: 15 frequency: 1
 
 pricy:
 doc: 15 frequency: 1
 
+boots:
+doc: 15 frequency: 1
+
+chrome:
+doc: 15 frequency: 1
+
+plated:
+doc: 15 frequency: 1
+
 bike:
+doc: 15 frequency: 1
+
+accesories:
+doc: 15 frequency: 1
+
+result:
 doc: 15 frequency: 1
 
 become:
@@ -4428,14 +6232,14 @@ doc: 24 frequency: 1
 hiring:
 doc: 15 frequency: 1
 
+practices:
+doc: 15 frequency: 1
+
 ads:
 doc: 15 frequency: 1
 
 mechanics:
 doc: 15 frequency: 1
-
-shop:
-doc: 15 frequency: 2
 
 lines:
 doc: 15 frequency: 1
@@ -4444,7 +6248,20 @@ doc: 29 frequency: 1
 progressive:
 doc: 15 frequency: 1
 
+dealership:
+doc: 15 frequency: 2
+
 dental:
+doc: 15 frequency: 1
+
+plan:
+doc: 15 frequency: 1
+
+team:
+doc: 15 frequency: 1
+doc: 28 frequency: 1
+
+oriented:
 doc: 15 frequency: 1
 
 approach:
@@ -4452,12 +6269,48 @@ doc: 15 frequency: 1
 
 customer:
 doc: 15 frequency: 1
-doc: 28 frequency: 1
+doc: 28 frequency: 2
+
+satisfaction:
+doc: 15 frequency: 1
+
+holdouts:
+doc: 15 frequency: 1
+
+ad:
+doc: 15 frequency: 1
 
 issue:
 doc: 15 frequency: 1
+doc: 20 frequency: 1
+
+thunder:
+doc: 15 frequency: 1
+
+press:
+doc: 15 frequency: 1
+doc: 19 frequency: 1
 
 national:
+doc: 15 frequency: 1
+
+magazine:
+doc: 15 frequency: 1
+doc: 20 frequency: 1
+
+wanted:
+doc: 15 frequency: 1
+
+freaks:
+doc: 15 frequency: 1
+
+misfits:
+doc: 15 frequency: 1
+
+miscreants:
+doc: 15 frequency: 1
+
+philistines:
 doc: 15 frequency: 1
 
 bunch:
@@ -4469,6 +6322,9 @@ doc: 15 frequency: 1
 bastards:
 doc: 15 frequency: 1
 
+slums:
+doc: 15 frequency: 1
+
 filthy:
 doc: 15 frequency: 1
 
@@ -4478,10 +6334,10 @@ doc: 15 frequency: 1
 bathroom:
 doc: 15 frequency: 1
 
-door:
+tuna:
 doc: 15 frequency: 1
 
-tuna:
+boat:
 doc: 15 frequency: 1
 
 mostly:
@@ -4507,6 +6363,7 @@ doc: 15 frequency: 1
 
 fire:
 doc: 15 frequency: 1
+doc: 18 frequency: 1
 
 read:
 doc: 15 frequency: 1
@@ -4514,29 +6371,43 @@ doc: 23 frequency: 1
 doc: 24 frequency: 1
 doc: 28 frequency: 1
 
+positions:
+doc: 15 frequency: 1
+
 call:
 doc: 15 frequency: 1
 
-paul:
-doc: 15 frequency: 1
-
-name:
-doc: 15 frequency: 1
-doc: 19 frequency: 1
-
 phone:
 doc: 15 frequency: 1
-doc: 21 frequency: 1
+doc: 21 frequency: 2
 doc: 23 frequency: 1
-
-changed:
-doc: 15 frequency: 1
 
 protect:
 doc: 15 frequency: 1
 
 history:
+doc: 16 frequency: 3
+
+mpsingh:
+doc: 16 frequency: 1
+
+eos:
+doc: 16 frequency: 1
+
+ncsu:
+doc: 16 frequency: 1
+
+munindar:
+doc: 16 frequency: 1
+
+singh:
+doc: 16 frequency: 1
+
+west:
 doc: 16 frequency: 2
+
+virginians:
+doc: 16 frequency: 1
 
 few:
 doc: 16 frequency: 1
@@ -4552,8 +6423,12 @@ doc: 16 frequency: 1
 clogged:
 doc: 16 frequency: 1
 
+arteries:
+doc: 16 frequency: 1
+
 first:
 doc: 16 frequency: 2
+doc: 17 frequency: 1
 doc: 18 frequency: 1
 doc: 19 frequency: 4
 doc: 28 frequency: 1
@@ -4561,7 +6436,7 @@ doc: 28 frequency: 1
 careful:
 doc: 16 frequency: 1
 
-diet:
+exercise:
 doc: 16 frequency: 1
 
 puts:
@@ -4579,24 +6454,51 @@ doc: 16 frequency: 1
 soon:
 doc: 16 frequency: 1
 doc: 19 frequency: 1
+doc: 24 frequency: 1
+
+god:
+doc: 16 frequency: 1
+doc: 18 frequency: 1
 
 am:
 doc: 16 frequency: 1
 doc: 23 frequency: 1
 doc: 28 frequency: 2
 
-west:
-doc: 16 frequency: 1
+hire:
+doc: 17 frequency: 2
+
+movers:
+doc: 17 frequency: 2
+
+nivlac:
+doc: 17 frequency: 1
+
+widomaker:
+doc: 17 frequency: 1
+
+finke:
+doc: 17 frequency: 1
+
+laugh:
+doc: 17 frequency: 1
+doc: 29 frequency: 1
+
+moversnet:
+doc: 17 frequency: 1
+
+howtopacka:
+doc: 17 frequency: 1
+
+moving:
+doc: 17 frequency: 3
+
+packing:
+doc: 17 frequency: 2
 
 sites:
 doc: 17 frequency: 1
 doc: 19 frequency: 1
-
-today:
-doc: 17 frequency: 1
-doc: 22 frequency: 1
-doc: 26 frequency: 1
-doc: 28 frequency: 2
 
 usps:
 doc: 17 frequency: 1
@@ -4605,6 +6507,12 @@ site:
 doc: 17 frequency: 1
 doc: 19 frequency: 2
 
+places:
+doc: 17 frequency: 1
+
+humorous:
+doc: 17 frequency: 1
+
 stuck:
 doc: 17 frequency: 1
 
@@ -4612,37 +6520,68 @@ among:
 doc: 17 frequency: 1
 
 pack:
+doc: 17 frequency: 2
+
+china:
 doc: 17 frequency: 1
 
-packing:
+appliances:
 doc: 17 frequency: 1
 
 hippos:
 doc: 17 frequency: 1
 
+need:
+doc: 17 frequency: 1
+doc: 23 frequency: 1
+doc: 24 frequency: 1
+doc: 28 frequency: 1
+
+gallon:
+doc: 17 frequency: 1
+
 tank:
-doc: 17 frequency: 2
+doc: 17 frequency: 3
+doc: 28 frequency: 2
 
 per:
 doc: 17 frequency: 1
 
+hippo:
+doc: 17 frequency: 7
+
 gallons:
+doc: 17 frequency: 3
+
+crane:
+doc: 17 frequency: 2
+
+pound:
+doc: 17 frequency: 1
+
+sedative:
 doc: 17 frequency: 2
 
 soothing:
 doc: 17 frequency: 2
 
-hippo:
-doc: 17 frequency: 5
-
 aspirin:
-doc: 17 frequency: 1
+doc: 17 frequency: 2
 
 fill:
 doc: 17 frequency: 1
 doc: 28 frequency: 2
 
+remember:
+doc: 17 frequency: 1
+
+sized:
+doc: 17 frequency: 1
+
 takes:
+doc: 17 frequency: 1
+
+curiosity:
 doc: 17 frequency: 1
 
 hold:
@@ -4667,11 +6606,14 @@ doc: 18 frequency: 1
 forklift:
 doc: 17 frequency: 1
 
-advocate:
+arrives:
 doc: 17 frequency: 1
 
-moving:
-doc: 17 frequency: 2
+waiver:
+doc: 17 frequency: 1
+
+advocate:
+doc: 17 frequency: 1
 
 without:
 doc: 17 frequency: 1
@@ -4689,11 +6631,21 @@ doc: 17 frequency: 1
 zoo:
 doc: 17 frequency: 1
 
+keeper:
+doc: 17 frequency: 1
+doc: 28 frequency: 1
+
 veterinarian:
 doc: 17 frequency: 1
 
 pets:
 doc: 17 frequency: 1
+
+jesus:
+doc: 18 frequency: 4
+
+returns:
+doc: 18 frequency: 2
 
 fatally:
 doc: 18 frequency: 3
@@ -4702,12 +6654,24 @@ burned:
 doc: 18 frequency: 3
 
 fireworks:
+doc: 18 frequency: 3
+
+christians:
 doc: 18 frequency: 2
+
+bethlehem:
+doc: 18 frequency: 2
+
+israel:
+doc: 18 frequency: 1
 
 jan:
 doc: 18 frequency: 1
 
-jesus:
+upi:
+doc: 18 frequency: 1
+
+christ:
 doc: 18 frequency: 1
 
 lord:
@@ -4716,17 +6680,13 @@ doc: 18 frequency: 2
 savior:
 doc: 18 frequency: 1
 
-christians:
-doc: 18 frequency: 1
-
-morning:
-doc: 18 frequency: 1
-doc: 28 frequency: 1
-
 reappearing:
 doc: 18 frequency: 1
 
 stroke:
+doc: 18 frequency: 1
+
+midnight:
 doc: 18 frequency: 1
 
 clad:
@@ -4739,7 +6699,7 @@ white:
 doc: 18 frequency: 1
 
 robes:
-doc: 18 frequency: 1
+doc: 18 frequency: 2
 
 wore:
 doc: 18 frequency: 1
@@ -4763,7 +6723,7 @@ atop:
 doc: 18 frequency: 1
 
 tower:
-doc: 18 frequency: 1
+doc: 18 frequency: 2
 
 central:
 doc: 18 frequency: 1
@@ -4771,20 +6731,17 @@ doc: 18 frequency: 1
 square:
 doc: 18 frequency: 1
 
-years:
+unfortunately:
 doc: 18 frequency: 1
-doc: 28 frequency: 1
 
 massive:
 doc: 18 frequency: 1
 
 display:
 doc: 18 frequency: 1
+doc: 28 frequency: 1
 
 celebrate:
-doc: 18 frequency: 1
-
-moment:
 doc: 18 frequency: 1
 
 quickly:
@@ -4793,7 +6750,20 @@ doc: 18 frequency: 1
 igniting:
 doc: 18 frequency: 1
 
+incarnation:
+doc: 18 frequency: 1
+
+retardant:
+doc: 18 frequency: 1
+
+th:
+doc: 18 frequency: 1
+
 century:
+doc: 18 frequency: 1
+doc: 28 frequency: 1
+
+standards:
 doc: 18 frequency: 1
 
 pelted:
@@ -4803,7 +6773,10 @@ crazed:
 doc: 18 frequency: 1
 
 doves:
-doc: 18 frequency: 1
+doc: 18 frequency: 2
+
+peace:
+doc: 18 frequency: 2
 
 released:
 doc: 18 frequency: 1
@@ -4811,7 +6784,10 @@ doc: 18 frequency: 1
 amid:
 doc: 18 frequency: 1
 
-god:
+explosions:
+doc: 18 frequency: 1
+
+stories:
 doc: 18 frequency: 1
 
 prince:
@@ -4827,6 +6803,9 @@ mount:
 doc: 18 frequency: 1
 
 sinai:
+doc: 18 frequency: 2
+
+hospital:
 doc: 18 frequency: 1
 
 burn:
@@ -4841,19 +6820,19 @@ doc: 18 frequency: 1
 died:
 doc: 18 frequency: 1
 
-brief:
-doc: 18 frequency: 1
-
 interview:
 doc: 18 frequency: 1
 
-member:
+reporters:
 doc: 18 frequency: 1
 
 holy:
 doc: 18 frequency: 1
 
 trinity:
+doc: 18 frequency: 1
+
+hardened:
 doc: 18 frequency: 1
 
 mainly:
@@ -4868,7 +6847,13 @@ doc: 18 frequency: 1
 prophets:
 doc: 18 frequency: 1
 
+rule:
+doc: 18 frequency: 1
+
 thousand:
+doc: 18 frequency: 2
+
+return:
 doc: 18 frequency: 2
 
 indicated:
@@ -4889,6 +6874,9 @@ doc: 18 frequency: 1
 interpretations:
 doc: 18 frequency: 1
 
+bible:
+doc: 18 frequency: 1
+
 worried:
 doc: 18 frequency: 1
 
@@ -4898,13 +6886,26 @@ doc: 18 frequency: 1
 match:
 doc: 18 frequency: 1
 
+hell:
+doc: 18 frequency: 1
+
 survived:
 doc: 18 frequency: 1
+
+miraculous:
+doc: 18 frequency: 1
+
+dr:
+doc: 18 frequency: 2
+doc: 20 frequency: 1
 
 josh:
 doc: 18 frequency: 1
 
 levi:
+doc: 18 frequency: 2
+
+mt:
 doc: 18 frequency: 1
 
 think:
@@ -4917,6 +6918,16 @@ doc: 18 frequency: 1
 
 realized:
 doc: 18 frequency: 1
+
+jewish:
+doc: 18 frequency: 1
+
+rest:
+doc: 18 frequency: 1
+
+second:
+doc: 19 frequency: 3
+doc: 28 frequency: 1
 
 grader:
 doc: 19 frequency: 3
@@ -4931,29 +6942,32 @@ makes:
 doc: 19 frequency: 2
 doc: 28 frequency: 1
 
-day:
-doc: 19 frequency: 3
-doc: 24 frequency: 2
-doc: 28 frequency: 2
-
 trading:
+doc: 19 frequency: 4
+
+weeklygrumble:
 doc: 19 frequency: 1
 
+timmy:
+doc: 19 frequency: 5
+
 paper:
+doc: 19 frequency: 1
+
+boy:
 doc: 19 frequency: 1
 
 weekly:
 doc: 19 frequency: 2
 
-ca:
-doc: 19 frequency: 1
-
-second:
-doc: 19 frequency: 1
-doc: 28 frequency: 1
-
-timmy:
+grumble:
 doc: 19 frequency: 2
+
+silicon:
+doc: 19 frequency: 1
+
+valley:
+doc: 19 frequency: 1
 
 watson:
 doc: 19 frequency: 1
@@ -4978,21 +6992,23 @@ doc: 19 frequency: 1
 love:
 doc: 19 frequency: 5
 
+kitty:
+doc: 19 frequency: 5
+
 nasdaq:
 doc: 19 frequency: 1
-
-stock:
-doc: 19 frequency: 3
-doc: 28 frequency: 1
 
 exchange:
 doc: 19 frequency: 1
 
-kitty:
-doc: 19 frequency: 3
-
 llc:
 doc: 19 frequency: 2
+
+ktty:
+doc: 19 frequency: 1
+
+thirty:
+doc: 19 frequency: 1
 
 rocketed:
 doc: 19 frequency: 1
@@ -5007,6 +7023,16 @@ doc: 19 frequency: 2
 whopping:
 doc: 19 frequency: 1
 
+four:
+doc: 19 frequency: 1
+
+hundred:
+doc: 19 frequency: 1
+doc: 24 frequency: 1
+
+sixty:
+doc: 19 frequency: 1
+
 explains:
 doc: 19 frequency: 1
 
@@ -5016,14 +7042,23 @@ doc: 19 frequency: 2
 loves:
 doc: 19 frequency: 1
 
+mittens:
+doc: 19 frequency: 1
+
 investors:
 doc: 19 frequency: 3
 
 hoping:
 doc: 19 frequency: 1
 
+build:
+doc: 19 frequency: 1
+
 radical:
 doc: 19 frequency: 1
+
+commerce:
+doc: 19 frequency: 2
 
 according:
 doc: 19 frequency: 1
@@ -5031,17 +7066,36 @@ doc: 19 frequency: 1
 saul:
 doc: 19 frequency: 1
 
+schlepstein:
+doc: 19 frequency: 1
+
 expert:
+doc: 19 frequency: 1
+
+ilmk:
+doc: 19 frequency: 4
+
+amazon:
 doc: 19 frequency: 1
 
 mean:
 doc: 19 frequency: 1
 doc: 28 frequency: 1
 
+everything:
+doc: 19 frequency: 1
+doc: 30 frequency: 1
+
 cute:
 doc: 19 frequency: 1
 
+cats:
+doc: 19 frequency: 1
+
 strongest:
+doc: 19 frequency: 1
+
+amazing:
 doc: 19 frequency: 1
 
 wet:
@@ -5054,13 +7108,14 @@ older:
 doc: 19 frequency: 1
 
 sister:
-doc: 19 frequency: 1
+doc: 19 frequency: 2
 
 tanya:
-doc: 19 frequency: 1
+doc: 19 frequency: 3
 
 reported:
 doc: 19 frequency: 1
+doc: 28 frequency: 1
 
 creating:
 doc: 19 frequency: 1
@@ -5071,11 +7126,8 @@ doc: 19 frequency: 1
 entitled:
 doc: 19 frequency: 1
 
-buying:
+barbie:
 doc: 19 frequency: 1
-
-ilmk:
-doc: 19 frequency: 2
 
 ilmb:
 doc: 19 frequency: 1
@@ -5111,14 +7163,16 @@ doc: 19 frequency: 1
 fourth:
 doc: 19 frequency: 1
 
-us:
+grade:
 doc: 19 frequency: 1
-doc: 29 frequency: 1
 
 suspect:
 doc: 19 frequency: 1
 
 marketable:
+doc: 19 frequency: 1
+
+product:
 doc: 19 frequency: 1
 
 fears:
@@ -5136,9 +7190,6 @@ doc: 19 frequency: 1
 informed:
 doc: 19 frequency: 1
 
-press:
-doc: 19 frequency: 1
-
 seems:
 doc: 19 frequency: 1
 doc: 24 frequency: 1
@@ -5147,6 +7198,9 @@ virulent:
 doc: 19 frequency: 1
 
 strain:
+doc: 19 frequency: 1
+
+cooties:
 doc: 19 frequency: 1
 
 fine:
@@ -5158,16 +7212,47 @@ doc: 19 frequency: 1
 brought:
 doc: 19 frequency: 1
 
+bleach:
+doc: 19 frequency: 1
+
+copyrighted:
+doc: 19 frequency: 1
+
 gist:
 doc: 19 frequency: 1
 
 pass:
 doc: 19 frequency: 1
 
+along:
+doc: 19 frequency: 1
+
 include:
 doc: 19 frequency: 1
 
+tag:
+doc: 19 frequency: 1
+
+line:
+doc: 19 frequency: 1
+doc: 28 frequency: 1
+
+quick:
+doc: 20 frequency: 2
+
+csc:
+doc: 20 frequency: 1
+
+tjm:
+doc: 20 frequency: 1
+
+shsu:
+doc: 20 frequency: 1
+
 tim:
+doc: 20 frequency: 1
+
+mcguire:
 doc: 20 frequency: 1
 
 sam:
@@ -5183,11 +7268,15 @@ doc: 20 frequency: 1
 ribbing:
 doc: 20 frequency: 1
 
-magazine:
+married:
+doc: 20 frequency: 2
+
+playboy:
 doc: 20 frequency: 1
 
-married:
+men:
 doc: 20 frequency: 1
+doc: 27 frequency: 3
 
 woman:
 doc: 20 frequency: 1
@@ -5198,13 +7287,39 @@ doc: 20 frequency: 1
 fast:
 doc: 20 frequency: 1
 
+comeback:
+doc: 20 frequency: 1
+
 immediately:
+doc: 20 frequency: 1
+
+retorted:
 doc: 20 frequency: 1
 
 frequency:
 doc: 20 frequency: 1
 
-christmas:
+daily:
+doc: 20 frequency: 1
+doc: 24 frequency: 1
+
+bks:
+doc: 21 frequency: 1
+
+q:
+doc: 21 frequency: 1
+doc: 23 frequency: 3
+
+unix:
+doc: 21 frequency: 1
+
+mail:
+doc: 21 frequency: 1
+
+brian:
+doc: 21 frequency: 1
+
+sward:
 doc: 21 frequency: 1
 
 mhz:
@@ -5225,17 +7340,27 @@ doc: 21 frequency: 1
 
 times:
 doc: 21 frequency: 1
+doc: 23 frequency: 1
 
 faster:
 doc: 21 frequency: 1
 
+ineffective:
+doc: 22 frequency: 2
+
 protest:
-doc: 22 frequency: 1
+doc: 22 frequency: 2
+
+aucoin:
+doc: 22 frequency: 2
 
 headline:
 doc: 22 frequency: 1
 
 chronicle:
+doc: 22 frequency: 1
+
+death:
 doc: 22 frequency: 1
 
 row:
@@ -5250,6 +7375,18 @@ doc: 22 frequency: 1
 hunger:
 doc: 22 frequency: 1
 
+strike:
+doc: 22 frequency: 1
+
+quality:
+doc: 23 frequency: 3
+
+hfarkas:
+doc: 23 frequency: 1
+
+ibm:
+doc: 23 frequency: 1
+
 job:
 doc: 23 frequency: 1
 
@@ -5262,10 +7399,8 @@ doc: 23 frequency: 1
 section:
 doc: 23 frequency: 1
 
-need:
+thermometers:
 doc: 23 frequency: 1
-doc: 24 frequency: 1
-doc: 28 frequency: 1
 
 rectal:
 doc: 23 frequency: 2
@@ -5273,13 +7408,22 @@ doc: 23 frequency: 2
 thermometer:
 doc: 23 frequency: 5
 
+tip:
+doc: 23 frequency: 3
+
 draw:
+doc: 23 frequency: 1
+
+drapes:
 doc: 23 frequency: 1
 
 disconnect:
 doc: 23 frequency: 1
 
 disturbed:
+doc: 23 frequency: 1
+
+therapy:
 doc: 23 frequency: 1
 
 change:
@@ -5291,7 +7435,13 @@ doc: 23 frequency: 1
 sweat:
 doc: 23 frequency: 1
 
+suit:
+doc: 23 frequency: 1
+
 lie:
+doc: 23 frequency: 1
+
+bed:
 doc: 23 frequency: 1
 
 package:
@@ -5306,10 +7456,10 @@ doc: 23 frequency: 1
 bedside:
 doc: 23 frequency: 1
 
-table:
+chipped:
 doc: 23 frequency: 1
 
-chipped:
+broken:
 doc: 23 frequency: 1
 
 written:
@@ -5334,6 +7484,9 @@ doc: 23 frequency: 1
 personally:
 doc: 23 frequency: 1
 
+tested:
+doc: 23 frequency: 1
+
 eyes:
 doc: 23 frequency: 1
 
@@ -5341,9 +7494,6 @@ loud:
 doc: 23 frequency: 1
 
 glad:
-doc: 23 frequency: 1
-
-quality:
 doc: 23 frequency: 1
 
 follows:
@@ -5355,15 +7505,38 @@ doc: 24 frequency: 1
 submitted:
 doc: 24 frequency: 1
 
-topical:
+nature:
 doc: 24 frequency: 1
 
 includes:
 doc: 24 frequency: 1
 
+sensitive:
+doc: 24 frequency: 1
+
+andrewd:
+doc: 24 frequency: 1
+
+nospam:
+doc: 24 frequency: 1
+
+ozemail:
+doc: 24 frequency: 1
+
+andrew:
+doc: 24 frequency: 1
+
+davis:
+doc: 24 frequency: 1
+
 millennium:
-doc: 24 frequency: 2
+doc: 24 frequency: 3
+doc: 28 frequency: 1
+doc: 29 frequency: 1
 doc: 30 frequency: 1
+
+listening:
+doc: 24 frequency: 1
 
 voice:
 doc: 24 frequency: 1
@@ -5385,6 +7558,10 @@ doc: 24 frequency: 1
 
 quite:
 doc: 24 frequency: 1
+doc: 28 frequency: 1
+
+tiresome:
+doc: 24 frequency: 1
 
 wished:
 doc: 24 frequency: 1
@@ -5396,13 +7573,16 @@ doc: 24 frequency: 3
 removed:
 doc: 24 frequency: 1
 
+vocabulary:
+doc: 24 frequency: 1
+
 reinstate:
 doc: 24 frequency: 1
 
-hundred:
+candywhip:
 doc: 24 frequency: 1
 
-m:
+bonfire:
 doc: 24 frequency: 2
 
 officials:
@@ -5411,11 +7591,30 @@ doc: 24 frequency: 1
 conducting:
 doc: 24 frequency: 1
 
-bonfire:
+tradition:
+doc: 24 frequency: 1
+
+far:
 doc: 24 frequency: 1
 
 poled:
 doc: 24 frequency: 1
+
+students:
+doc: 24 frequency: 1
+
+tony:
+doc: 24 frequency: 2
+
+reserv:
+doc: 24 frequency: 1
+
+usf:
+doc: 24 frequency: 1
+
+while:
+doc: 24 frequency: 2
+doc: 28 frequency: 1
 
 waiting:
 doc: 24 frequency: 1
@@ -5429,10 +7628,10 @@ doc: 24 frequency: 2
 toy:
 doc: 24 frequency: 1
 
-licences:
-doc: 24 frequency: 1
-
 season:
+doc: 24 frequency: 2
+
+licences:
 doc: 24 frequency: 1
 
 aggietown:
@@ -5450,20 +7649,42 @@ doc: 24 frequency: 1
 jenga:
 doc: 24 frequency: 1
 
+neden:
+doc: 24 frequency: 2
+
+thetoybox:
+doc: 24 frequency: 1
+
+kevin:
+doc: 24 frequency: 1
+
+mensa:
+doc: 24 frequency: 2
+
+readiness:
+doc: 24 frequency: 1
+doc: 28 frequency: 1
+
 lined:
 doc: 24 frequency: 1
 
 discount:
 doc: 24 frequency: 1
+doc: 28 frequency: 1
+
+calendar:
+doc: 24 frequency: 3
+doc: 28 frequency: 1
 
 spotted:
 doc: 24 frequency: 1
 
-daily:
+admittedly:
 doc: 24 frequency: 1
 
 calendars:
 doc: 24 frequency: 1
+doc: 30 frequency: 1
 
 sale:
 doc: 24 frequency: 1
@@ -5478,6 +7699,30 @@ doc: 24 frequency: 1
 leap:
 doc: 24 frequency: 1
 
+ebay:
+doc: 25 frequency: 2
+
+fun:
+doc: 25 frequency: 2
+
+alanh:
+doc: 25 frequency: 1
+
+nelson:
+doc: 25 frequency: 1
+
+oit:
+doc: 25 frequency: 1
+
+unc:
+doc: 25 frequency: 1
+
+alan:
+doc: 25 frequency: 1
+
+hoyle:
+doc: 25 frequency: 1
+
 exactly:
 doc: 25 frequency: 1
 
@@ -5487,13 +7732,38 @@ doc: 25 frequency: 1
 appropriate:
 doc: 25 frequency: 1
 
+however:
+doc: 25 frequency: 1
+doc: 28 frequency: 1
+
 url:
 doc: 25 frequency: 1
 
 exceptionally:
 doc: 25 frequency: 1
 
+aw:
+doc: 25 frequency: 1
+
+cgi:
+doc: 25 frequency: 1
+
+ebayisapi:
+doc: 25 frequency: 1
+
+dll:
+doc: 25 frequency: 1
+
+viewitem:
+doc: 25 frequency: 1
+
 item:
+doc: 25 frequency: 2
+
+snow:
+doc: 25 frequency: 1
+
+powder:
 doc: 25 frequency: 1
 
 buyer:
@@ -5505,14 +7775,23 @@ doc: 25 frequency: 1
 located:
 doc: 25 frequency: 1
 
+durham:
+doc: 25 frequency: 1
+
 north:
 doc: 25 frequency: 1
 
 carolina:
 doc: 25 frequency: 1
 
+superbowl:
+doc: 26 frequency: 4
+
 pornography:
-doc: 26 frequency: 2
+doc: 26 frequency: 3
+
+davychild:
+doc: 26 frequency: 1
 
 often:
 doc: 26 frequency: 1
@@ -5553,20 +7832,54 @@ doc: 26 frequency: 1
 blocked:
 doc: 26 frequency: 1
 
-superbowl:
+xxxiv:
 doc: 26 frequency: 1
 
 ten:
-doc: 27 frequency: 3
-
-men:
 doc: 27 frequency: 3
 
 understand:
 doc: 27 frequency: 3
 
 women:
-doc: 27 frequency: 2
+doc: 27 frequency: 3
+
+markb:
+doc: 27 frequency: 1
+
+stanford:
+doc: 27 frequency: 1
+
+branom:
+doc: 27 frequency: 1
+
+sexist:
+doc: 27 frequency: 1
+doc: 28 frequency: 1
+
+received:
+doc: 28 frequency: 1
+
+davidrs:
+doc: 28 frequency: 1
+
+atl:
+doc: 28 frequency: 1
+
+fundtech:
+doc: 28 frequency: 1
+
+david:
+doc: 28 frequency: 2
+
+stabler:
+doc: 28 frequency: 1
+
+russia:
+doc: 28 frequency: 2
+
+woes:
+doc: 28 frequency: 1
 
 boris:
 doc: 28 frequency: 1
@@ -5580,31 +7893,39 @@ doc: 28 frequency: 1
 presidency:
 doc: 28 frequency: 1
 
-russia:
-doc: 28 frequency: 1
-
 surprise:
 doc: 28 frequency: 1
 
 checked:
 doc: 28 frequency: 1
+doc: 29 frequency: 3
+
+compliancy:
+doc: 28 frequency: 1
+
+laird:
+doc: 28 frequency: 2
+
+cs:
+doc: 28 frequency: 1
+
+byu:
+doc: 28 frequency: 1
 
 j:
-doc: 28 frequency: 1
+doc: 28 frequency: 2
 
-bug:
+hype:
 doc: 28 frequency: 1
-doc: 30 frequency: 4
 
 scarcely:
 doc: 28 frequency: 1
 
-overhyped:
+noise:
 doc: 28 frequency: 1
 
-event:
-doc: 28 frequency: 2
-doc: 29 frequency: 1
+overhyped:
+doc: 28 frequency: 1
 
 behind:
 doc: 28 frequency: 1
@@ -5612,10 +7933,31 @@ doc: 28 frequency: 1
 star:
 doc: 28 frequency: 1
 
+wars:
+doc: 28 frequency: 1
+
 episode:
 doc: 28 frequency: 1
 
+lcrocker:
+doc: 28 frequency: 1
+
+mercury:
+doc: 28 frequency: 1
+
+colossus:
+doc: 28 frequency: 1
+
+lee:
+doc: 28 frequency: 1
+
+crocker:
+doc: 28 frequency: 1
+
 piclab:
+doc: 28 frequency: 1
+
+feature:
 doc: 28 frequency: 1
 
 electronic:
@@ -5642,17 +7984,32 @@ doc: 28 frequency: 1
 plugged:
 doc: 28 frequency: 1
 
-date:
+correct:
+doc: 28 frequency: 1
+
+tcomeau:
 doc: 28 frequency: 1
 
 stsci:
+doc: 28 frequency: 2
+
+tom:
+doc: 28 frequency: 2
+
+comeau:
 doc: 28 frequency: 1
 
 archive:
 doc: 28 frequency: 1
 
+fwd:
+doc: 28 frequency: 2
+
+warning:
+doc: 28 frequency: 1
+
 gap:
-doc: 28 frequency: 5
+doc: 28 frequency: 7
 
 employee:
 doc: 28 frequency: 1
@@ -5663,6 +8020,9 @@ doc: 28 frequency: 1
 remain:
 doc: 28 frequency: 1
 
+anonymous:
+doc: 28 frequency: 1
+
 earlier:
 doc: 28 frequency: 2
 
@@ -5670,22 +8030,32 @@ discussions:
 doc: 28 frequency: 1
 
 zipper:
-doc: 28 frequency: 4
+doc: 28 frequency: 5
 
-while:
-doc: 28 frequency: 1
-
-true:
+compliance:
 doc: 28 frequency: 1
 
 user:
+doc: 28 frequency: 1
+doc: 30 frequency: 2
+
+interface:
+doc: 28 frequency: 1
+
+gui:
 doc: 28 frequency: 1
 
 labelled:
 doc: 28 frequency: 1
 
+logo:
+doc: 28 frequency: 1
+
 system:
 doc: 28 frequency: 2
+
+ykk:
+doc: 28 frequency: 1
 
 japanese:
 doc: 28 frequency: 1
@@ -5696,17 +8066,17 @@ doc: 28 frequency: 1
 zippers:
 doc: 28 frequency: 2
 
+compliant:
+doc: 28 frequency: 5
+
 vendors:
 doc: 28 frequency: 1
 
 confident:
 doc: 28 frequency: 1
 
-including:
+merchandise:
 doc: 28 frequency: 1
-
-compliant:
-doc: 28 frequency: 2
 
 operate:
 doc: 28 frequency: 1
@@ -5729,31 +8099,72 @@ doc: 28 frequency: 1
 cases:
 doc: 28 frequency: 1
 
+failure:
+doc: 28 frequency: 1
+
 safety:
 doc: 28 frequency: 1
 
 step:
-doc: 28 frequency: 1
+doc: 28 frequency: 2
 
 downing:
 doc: 28 frequency: 1
 
-necessary:
-doc: 28 frequency: 2
+turnover:
+doc: 28 frequency: 1
 
 contact:
 doc: 28 frequency: 1
 
-line:
+style:
+doc: 28 frequency: 1
+
+finder:
+doc: 28 frequency: 1
+
+vega:
+doc: 28 frequency: 1
+
+paithankar:
 doc: 28 frequency: 1
 
 celebrating:
 doc: 28 frequency: 1
 
+merlin:
+doc: 28 frequency: 2
+
+hansen:
+doc: 28 frequency: 2
+
+sk:
+doc: 28 frequency: 1
+
+sympatico:
+doc: 28 frequency: 2
+
+fix:
+doc: 28 frequency: 1
+
+missed:
+doc: 28 frequency: 1
+
+december:
+doc: 28 frequency: 1
+doc: 29 frequency: 1
+
+st:
+doc: 28 frequency: 1
+doc: 29 frequency: 1
+
 approximately:
 doc: 28 frequency: 1
 
 withdraw:
+doc: 28 frequency: 2
+
+atm:
 doc: 28 frequency: 2
 
 preparing:
@@ -5772,6 +8183,9 @@ doc: 28 frequency: 1
 near:
 doc: 28 frequency: 1
 
+bottom:
+doc: 28 frequency: 1
+
 obviously:
 doc: 28 frequency: 1
 
@@ -5784,28 +8198,37 @@ doc: 28 frequency: 1
 clients:
 doc: 28 frequency: 1
 
-extra:
-doc: 28 frequency: 2
-
 assurance:
-doc: 28 frequency: 1
-
-banks:
 doc: 28 frequency: 1
 
 preparations:
 doc: 28 frequency: 2
 
-atm:
-doc: 28 frequency: 1
-
 ready:
 doc: 28 frequency: 2
+
+gmwade:
+doc: 28 frequency: 1
+
+worldnet:
+doc: 28 frequency: 1
+
+att:
+doc: 28 frequency: 1
+
+gina:
+doc: 28 frequency: 1
 
 marie:
 doc: 28 frequency: 1
 
+wade:
+doc: 28 frequency: 1
+
 coda:
+doc: 28 frequency: 1
+
+wives:
 doc: 28 frequency: 1
 
 roll:
@@ -5814,19 +8237,28 @@ doc: 28 frequency: 1
 doing:
 doc: 28 frequency: 1
 
+housework:
+doc: 28 frequency: 1
+
 booting:
 doc: 28 frequency: 1
 
-dates:
+djfiander:
 doc: 28 frequency: 1
 
-readiness:
+fiander:
 doc: 28 frequency: 1
+
+dates:
+doc: 28 frequency: 2
 
 western:
 doc: 28 frequency: 1
 
 ontario:
+doc: 28 frequency: 1
+
+htm:
 doc: 28 frequency: 1
 
 third:
@@ -5847,19 +8279,35 @@ doc: 28 frequency: 1
 computing:
 doc: 28 frequency: 1
 
+week:
+doc: 28 frequency: 1
+
 artificial:
 doc: 28 frequency: 1
 
 intelligence:
 doc: 28 frequency: 1
 
-fail:
-doc: 28 frequency: 1
-
 ethical:
 doc: 28 frequency: 1
 
 dilemma:
+doc: 28 frequency: 1
+
+tests:
+doc: 28 frequency: 1
+doc: 29 frequency: 1
+
+tkraemer:
+doc: 28 frequency: 1
+
+std:
+doc: 28 frequency: 1
+
+kraemer:
+doc: 28 frequency: 1
+
+nitpicking:
 doc: 28 frequency: 1
 
 liquor:
@@ -5871,10 +8319,46 @@ doc: 28 frequency: 1
 scotch:
 doc: 28 frequency: 1
 
+reasoning:
+doc: 28 frequency: 1
+
+hmmph:
+doc: 28 frequency: 1
+
+decade:
+doc: 28 frequency: 1
+
+nope:
+doc: 28 frequency: 1
+
+ummm:
+doc: 28 frequency: 1
+
+seconds:
+doc: 28 frequency: 1
+
 saturday:
 doc: 28 frequency: 1
 
+february:
+doc: 28 frequency: 1
+
 jeopardized:
+doc: 28 frequency: 1
+
+frequent:
+doc: 28 frequency: 1
+
+pearl:
+doc: 28 frequency: 2
+
+sw:
+doc: 28 frequency: 1
+
+stratus:
+doc: 28 frequency: 1
+
+dan:
 doc: 28 frequency: 1
 
 hearing:
@@ -5898,14 +8382,23 @@ doc: 28 frequency: 1
 experts:
 doc: 28 frequency: 1
 
+giving:
+doc: 28 frequency: 1
+
 gas:
 doc: 28 frequency: 2
 
 canned:
 doc: 28 frequency: 1
 
+goods:
+doc: 28 frequency: 1
+
 bathtub:
 doc: 28 frequency: 2
+
+wasn:
+doc: 28 frequency: 1
 
 fully:
 doc: 28 frequency: 1
@@ -5929,7 +8422,7 @@ doc: 28 frequency: 1
 soaked:
 doc: 28 frequency: 1
 
-water:
+gasoline:
 doc: 28 frequency: 1
 
 filled:
@@ -5938,7 +8431,16 @@ doc: 28 frequency: 1
 baked:
 doc: 28 frequency: 1
 
+beans:
+doc: 28 frequency: 1
+
 followup:
+doc: 29 frequency: 2
+
+ack:
+doc: 29 frequency: 1
+
+netins:
 doc: 29 frequency: 1
 
 lot:
@@ -5953,13 +8455,22 @@ doc: 29 frequency: 1
 relief:
 doc: 29 frequency: 1
 
+planning:
+doc: 29 frequency: 1
+
+programming:
+doc: 29 frequency: 1
+
 stockpiling:
+doc: 29 frequency: 1
+
+hoarding:
 doc: 29 frequency: 1
 
 documents:
 doc: 29 frequency: 1
 
-files:
+archived:
 doc: 29 frequency: 1
 
 millions:
@@ -5989,26 +8500,41 @@ doc: 29 frequency: 1
 evening:
 doc: 29 frequency: 1
 
-december:
-doc: 29 frequency: 1
-
 someday:
 doc: 29 frequency: 1
 
 look:
 doc: 29 frequency: 1
 
+senile:
+doc: 29 frequency: 1
+
 farts:
 doc: 29 frequency: 1
 
+milennium:
+doc: 30 frequency: 2
+
 microsoft:
-doc: 30 frequency: 4
+doc: 30 frequency: 5
+
+fashion:
+doc: 30 frequency: 2
+
+coedana:
+doc: 30 frequency: 1
 
 passed:
 doc: 30 frequency: 1
 
+hassle:
+doc: 30 frequency: 1
+
 believe:
 doc: 30 frequency: 2
+
+naivity:
+doc: 30 frequency: 1
 
 paid:
 doc: 30 frequency: 1
@@ -6016,18 +8542,27 @@ doc: 30 frequency: 1
 attention:
 doc: 30 frequency: 2
 
+reputation:
+doc: 30 frequency: 1
+
 warn:
 doc: 30 frequency: 1
 
 dear:
 doc: 30 frequency: 1
 
-everything:
+else:
 doc: 30 frequency: 1
 
 delayed:
 doc: 30 frequency: 1
 
 release:
+doc: 30 frequency: 1
+
+june:
+doc: 30 frequency: 1
+
+warned:
 doc: 30 frequency: 1
 

--- a/Part 1/Part_1.py
+++ b/Part 1/Part_1.py
@@ -36,6 +36,35 @@ class LinkedList:
             print(f"doc: {current.doc_id} frequency: {current.frequency}")
             current = current.next
 
+def extract_words_from_html(text):
+    words = []
+    current_word = []
+    in_tag = False
+
+    # Iterate through each character in the text
+    for char in text:
+        # Start of HTML tag
+        if char == '<':
+            in_tag = True
+            if current_word:
+                words.append(''.join(current_word))
+                current_word = []
+        # End of HTML tag
+        elif char == '>':
+            in_tag = False
+        # Outside of HTML tags
+        elif not in_tag:
+            if char.isalpha():
+                current_word.append(char)
+            else:
+                if current_word:
+                    words.append(''.join(current_word))
+                    current_word = []
+    # Add the last word to the list if exists
+    if current_word:
+        words.append(''.join(current_word))
+
+    return words
 
 # Task 1 
 #extracts all of the information from a folder, file by file
@@ -54,13 +83,12 @@ def extract_words_from_files(directory_path):
                     with open(full_path, 'r') as f:
                         
                         file_info = f.read()
-                        split_info = file_info.split()
-                        for term in split_info:
-                            if term.isalpha():
-                                word = term.lower()
-                                if word not in word_frequency:
-                                    word_frequency[word] = LinkedList()
-                                word_frequency[word].update_list(i)
+        
+                        for term in extract_words_from_html(file_info):
+                            word = term.lower()
+                            if word not in word_frequency:
+                                word_frequency[word] = LinkedList()
+                            word_frequency[word].update_list(i)
                         i += 1
                 except Exception as e:
                     print(f"Error reading file {file_name}")
@@ -84,13 +112,12 @@ def extract_from_zip(zip_path):
                     
                     file_info_undecoded = file_in_zip.read()
                     file_info = file_info_undecoded.decode('utf-8')
-                    split_info = file_info.split()
-                    for term in split_info:
-                        if term.isalpha():
-                            word = term.lower()
-                            if word not in word_frequency:
-                                word_frequency[word] = LinkedList()
-                            word_frequency[word].update_list(i)
+
+                    for term in extract_words_from_html(file_info):
+                        word = term.lower()
+                        if word not in word_frequency:
+                            word_frequency[word] = LinkedList()
+                        word_frequency[word].update_list(i)
                     i += 1
     except FileNotFoundError:
         print("Directory not found")


### PR DESCRIPTION
I updated Task 1 to introduce a function to extract text from HTML files by skipping tags and collecting only alphabetic words. This improves our previous HTML text extraction  by correctly identifying visible words. Both extract_from_zip and extract_from_file were updated to use this new tokenization method. Typing the word 'music' into the program now results in the two files the word was found.  